### PR TITLE
Provide `viur script` command

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 build = "*"
 twine = "*"
+requests = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "68b3748157ff13f7442784e1309ab60861eeb957444e6bb252cf06b99ddee0a1"
+            "sha256": "0cc6a94e9cbdecd85444d3c32e84ab8858a2004d3511eaf111b864d54c05a017"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -18,185 +18,307 @@
     "default": {
         "bleach": {
             "hashes": [
-                "sha256:0900d8b37eba61a802ee40ac0061f8c2b5dee29c1927dd1d233e075ebf5a71da",
-                "sha256:4d2651ab93271d1129ac9cbc679f524565cc8a1b791909c4a51eac4446a15994"
+                "sha256:1a1a85c1595e07d8db14c5f09f09e6433502c51c595970edc090551f0db99414",
+                "sha256:33c16e3353dbd13028ab4799a0f89a83f113405c766e9c122df8a06f5b85b3f4"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.1.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0.0"
         },
         "build": {
             "hashes": [
-                "sha256:1aaadcd69338252ade4f7ec1265e1a19184bf916d84c9b7df095f423948cb89f",
-                "sha256:21b7ebbd1b22499c4dac536abc7606696ea4d909fd755e00f09f3c0f2c05e3c8"
+                "sha256:af266720050a66c893a6096a2f410989eeac74ff9a68ba194b3f6473e8e26171",
+                "sha256:d5b71264afdb5951d6704482aac78de887c80691c52b88a9ad195983ca2c9269"
             ],
             "index": "pypi",
-            "version": "==0.7.0"
+            "version": "==0.10.0"
         },
         "certifi": {
             "hashes": [
-                "sha256:78884e7c1d4b00ce3cea67b44566851c4343c120abd683433ce934a68ea58872",
-                "sha256:d62a0163eb4c2344ac042ab2bdf75399a71a2d8c7d47eac2e2ee91b9d6339569"
+                "sha256:35824b4c3a97115964b408844d64aa14db1cc518f6562e8d7261699d1350a9e3",
+                "sha256:4ad3232f5e926d6718ec31cfc1fcadfde020920e278684144551c91769c7bc18"
             ],
-            "version": "==2021.10.8"
+            "markers": "python_version >= '3.6'",
+            "version": "==2022.12.7"
         },
         "cffi": {
             "hashes": [
-                "sha256:00c878c90cb53ccfaae6b8bc18ad05d2036553e6d9d1d9dbcf323bbe83854ca3",
-                "sha256:0104fb5ae2391d46a4cb082abdd5c69ea4eab79d8d44eaaf79f1b1fd806ee4c2",
-                "sha256:06c48159c1abed75c2e721b1715c379fa3200c7784271b3c46df01383b593636",
-                "sha256:0808014eb713677ec1292301ea4c81ad277b6cdf2fdd90fd540af98c0b101d20",
-                "sha256:10dffb601ccfb65262a27233ac273d552ddc4d8ae1bf93b21c94b8511bffe728",
-                "sha256:14cd121ea63ecdae71efa69c15c5543a4b5fbcd0bbe2aad864baca0063cecf27",
-                "sha256:17771976e82e9f94976180f76468546834d22a7cc404b17c22df2a2c81db0c66",
-                "sha256:181dee03b1170ff1969489acf1c26533710231c58f95534e3edac87fff06c443",
-                "sha256:23cfe892bd5dd8941608f93348c0737e369e51c100d03718f108bf1add7bd6d0",
-                "sha256:263cc3d821c4ab2213cbe8cd8b355a7f72a8324577dc865ef98487c1aeee2bc7",
-                "sha256:2756c88cbb94231c7a147402476be2c4df2f6078099a6f4a480d239a8817ae39",
-                "sha256:27c219baf94952ae9d50ec19651a687b826792055353d07648a5695413e0c605",
-                "sha256:2a23af14f408d53d5e6cd4e3d9a24ff9e05906ad574822a10563efcef137979a",
-                "sha256:31fb708d9d7c3f49a60f04cf5b119aeefe5644daba1cd2a0fe389b674fd1de37",
-                "sha256:3415c89f9204ee60cd09b235810be700e993e343a408693e80ce7f6a40108029",
-                "sha256:3773c4d81e6e818df2efbc7dd77325ca0dcb688116050fb2b3011218eda36139",
-                "sha256:3b96a311ac60a3f6be21d2572e46ce67f09abcf4d09344c49274eb9e0bf345fc",
-                "sha256:3f7d084648d77af029acb79a0ff49a0ad7e9d09057a9bf46596dac9514dc07df",
-                "sha256:41d45de54cd277a7878919867c0f08b0cf817605e4eb94093e7516505d3c8d14",
-                "sha256:4238e6dab5d6a8ba812de994bbb0a79bddbdf80994e4ce802b6f6f3142fcc880",
-                "sha256:45db3a33139e9c8f7c09234b5784a5e33d31fd6907800b316decad50af323ff2",
-                "sha256:45e8636704eacc432a206ac7345a5d3d2c62d95a507ec70d62f23cd91770482a",
-                "sha256:4958391dbd6249d7ad855b9ca88fae690783a6be9e86df65865058ed81fc860e",
-                "sha256:4a306fa632e8f0928956a41fa8e1d6243c71e7eb59ffbd165fc0b41e316b2474",
-                "sha256:57e9ac9ccc3101fac9d6014fba037473e4358ef4e89f8e181f8951a2c0162024",
-                "sha256:59888172256cac5629e60e72e86598027aca6bf01fa2465bdb676d37636573e8",
-                "sha256:5e069f72d497312b24fcc02073d70cb989045d1c91cbd53979366077959933e0",
-                "sha256:64d4ec9f448dfe041705426000cc13e34e6e5bb13736e9fd62e34a0b0c41566e",
-                "sha256:6dc2737a3674b3e344847c8686cf29e500584ccad76204efea14f451d4cc669a",
-                "sha256:74fdfdbfdc48d3f47148976f49fab3251e550a8720bebc99bf1483f5bfb5db3e",
-                "sha256:75e4024375654472cc27e91cbe9eaa08567f7fbdf822638be2814ce059f58032",
-                "sha256:786902fb9ba7433aae840e0ed609f45c7bcd4e225ebb9c753aa39725bb3e6ad6",
-                "sha256:8b6c2ea03845c9f501ed1313e78de148cd3f6cad741a75d43a29b43da27f2e1e",
-                "sha256:91d77d2a782be4274da750752bb1650a97bfd8f291022b379bb8e01c66b4e96b",
-                "sha256:91ec59c33514b7c7559a6acda53bbfe1b283949c34fe7440bcf917f96ac0723e",
-                "sha256:920f0d66a896c2d99f0adbb391f990a84091179542c205fa53ce5787aff87954",
-                "sha256:a5263e363c27b653a90078143adb3d076c1a748ec9ecc78ea2fb916f9b861962",
-                "sha256:abb9a20a72ac4e0fdb50dae135ba5e77880518e742077ced47eb1499e29a443c",
-                "sha256:c2051981a968d7de9dd2d7b87bcb9c939c74a34626a6e2f8181455dd49ed69e4",
-                "sha256:c21c9e3896c23007803a875460fb786118f0cdd4434359577ea25eb556e34c55",
-                "sha256:c2502a1a03b6312837279c8c1bd3ebedf6c12c4228ddbad40912d671ccc8a962",
-                "sha256:d4d692a89c5cf08a8557fdeb329b82e7bf609aadfaed6c0d79f5a449a3c7c023",
-                "sha256:da5db4e883f1ce37f55c667e5c0de439df76ac4cb55964655906306918e7363c",
-                "sha256:e7022a66d9b55e93e1a845d8c9eba2a1bebd4966cd8bfc25d9cd07d515b33fa6",
-                "sha256:ef1f279350da2c586a69d32fc8733092fd32cc8ac95139a00377841f59a3f8d8",
-                "sha256:f54a64f8b0c8ff0b64d18aa76675262e1700f3995182267998c31ae974fbc382",
-                "sha256:f5c7150ad32ba43a07c4479f40241756145a1f03b43480e058cfd862bf5041c7",
-                "sha256:f6f824dc3bce0edab5f427efcfb1d63ee75b6fcb7282900ccaf925be84efb0fc",
-                "sha256:fd8a250edc26254fe5b33be00402e6d287f562b6a5b2152dec302fa15bb3e997",
-                "sha256:ffaa5c925128e29efbde7301d8ecaf35c8c60ffbcd6a1ffd3a552177c8e5e796"
+                "sha256:00a9ed42e88df81ffae7a8ab6d9356b371399b91dbdf0c3cb1e84c03a13aceb5",
+                "sha256:03425bdae262c76aad70202debd780501fabeaca237cdfddc008987c0e0f59ef",
+                "sha256:04ed324bda3cda42b9b695d51bb7d54b680b9719cfab04227cdd1e04e5de3104",
+                "sha256:0e2642fe3142e4cc4af0799748233ad6da94c62a8bec3a6648bf8ee68b1c7426",
+                "sha256:173379135477dc8cac4bc58f45db08ab45d228b3363adb7af79436135d028405",
+                "sha256:198caafb44239b60e252492445da556afafc7d1e3ab7a1fb3f0584ef6d742375",
+                "sha256:1e74c6b51a9ed6589199c787bf5f9875612ca4a8a0785fb2d4a84429badaf22a",
+                "sha256:2012c72d854c2d03e45d06ae57f40d78e5770d252f195b93f581acf3ba44496e",
+                "sha256:21157295583fe8943475029ed5abdcf71eb3911894724e360acff1d61c1d54bc",
+                "sha256:2470043b93ff09bf8fb1d46d1cb756ce6132c54826661a32d4e4d132e1977adf",
+                "sha256:285d29981935eb726a4399badae8f0ffdff4f5050eaa6d0cfc3f64b857b77185",
+                "sha256:30d78fbc8ebf9c92c9b7823ee18eb92f2e6ef79b45ac84db507f52fbe3ec4497",
+                "sha256:320dab6e7cb2eacdf0e658569d2575c4dad258c0fcc794f46215e1e39f90f2c3",
+                "sha256:33ab79603146aace82c2427da5ca6e58f2b3f2fb5da893ceac0c42218a40be35",
+                "sha256:3548db281cd7d2561c9ad9984681c95f7b0e38881201e157833a2342c30d5e8c",
+                "sha256:3799aecf2e17cf585d977b780ce79ff0dc9b78d799fc694221ce814c2c19db83",
+                "sha256:39d39875251ca8f612b6f33e6b1195af86d1b3e60086068be9cc053aa4376e21",
+                "sha256:3b926aa83d1edb5aa5b427b4053dc420ec295a08e40911296b9eb1b6170f6cca",
+                "sha256:3bcde07039e586f91b45c88f8583ea7cf7a0770df3a1649627bf598332cb6984",
+                "sha256:3d08afd128ddaa624a48cf2b859afef385b720bb4b43df214f85616922e6a5ac",
+                "sha256:3eb6971dcff08619f8d91607cfc726518b6fa2a9eba42856be181c6d0d9515fd",
+                "sha256:40f4774f5a9d4f5e344f31a32b5096977b5d48560c5592e2f3d2c4374bd543ee",
+                "sha256:4289fc34b2f5316fbb762d75362931e351941fa95fa18789191b33fc4cf9504a",
+                "sha256:470c103ae716238bbe698d67ad020e1db9d9dba34fa5a899b5e21577e6d52ed2",
+                "sha256:4f2c9f67e9821cad2e5f480bc8d83b8742896f1242dba247911072d4fa94c192",
+                "sha256:50a74364d85fd319352182ef59c5c790484a336f6db772c1a9231f1c3ed0cbd7",
+                "sha256:54a2db7b78338edd780e7ef7f9f6c442500fb0d41a5a4ea24fff1c929d5af585",
+                "sha256:5635bd9cb9731e6d4a1132a498dd34f764034a8ce60cef4f5319c0541159392f",
+                "sha256:59c0b02d0a6c384d453fece7566d1c7e6b7bae4fc5874ef2ef46d56776d61c9e",
+                "sha256:5d598b938678ebf3c67377cdd45e09d431369c3b1a5b331058c338e201f12b27",
+                "sha256:5df2768244d19ab7f60546d0c7c63ce1581f7af8b5de3eb3004b9b6fc8a9f84b",
+                "sha256:5ef34d190326c3b1f822a5b7a45f6c4535e2f47ed06fec77d3d799c450b2651e",
+                "sha256:6975a3fac6bc83c4a65c9f9fcab9e47019a11d3d2cf7f3c0d03431bf145a941e",
+                "sha256:6c9a799e985904922a4d207a94eae35c78ebae90e128f0c4e521ce339396be9d",
+                "sha256:70df4e3b545a17496c9b3f41f5115e69a4f2e77e94e1d2a8e1070bc0c38c8a3c",
+                "sha256:7473e861101c9e72452f9bf8acb984947aa1661a7704553a9f6e4baa5ba64415",
+                "sha256:8102eaf27e1e448db915d08afa8b41d6c7ca7a04b7d73af6514df10a3e74bd82",
+                "sha256:87c450779d0914f2861b8526e035c5e6da0a3199d8f1add1a665e1cbc6fc6d02",
+                "sha256:8b7ee99e510d7b66cdb6c593f21c043c248537a32e0bedf02e01e9553a172314",
+                "sha256:91fc98adde3d7881af9b59ed0294046f3806221863722ba7d8d120c575314325",
+                "sha256:94411f22c3985acaec6f83c6df553f2dbe17b698cc7f8ae751ff2237d96b9e3c",
+                "sha256:98d85c6a2bef81588d9227dde12db8a7f47f639f4a17c9ae08e773aa9c697bf3",
+                "sha256:9ad5db27f9cabae298d151c85cf2bad1d359a1b9c686a275df03385758e2f914",
+                "sha256:a0b71b1b8fbf2b96e41c4d990244165e2c9be83d54962a9a1d118fd8657d2045",
+                "sha256:a0f100c8912c114ff53e1202d0078b425bee3649ae34d7b070e9697f93c5d52d",
+                "sha256:a591fe9e525846e4d154205572a029f653ada1a78b93697f3b5a8f1f2bc055b9",
+                "sha256:a5c84c68147988265e60416b57fc83425a78058853509c1b0629c180094904a5",
+                "sha256:a66d3508133af6e8548451b25058d5812812ec3798c886bf38ed24a98216fab2",
+                "sha256:a8c4917bd7ad33e8eb21e9a5bbba979b49d9a97acb3a803092cbc1133e20343c",
+                "sha256:b3bbeb01c2b273cca1e1e0c5df57f12dce9a4dd331b4fa1635b8bec26350bde3",
+                "sha256:cba9d6b9a7d64d4bd46167096fc9d2f835e25d7e4c121fb2ddfc6528fb0413b2",
+                "sha256:cc4d65aeeaa04136a12677d3dd0b1c0c94dc43abac5860ab33cceb42b801c1e8",
+                "sha256:ce4bcc037df4fc5e3d184794f27bdaab018943698f4ca31630bc7f84a7b69c6d",
+                "sha256:cec7d9412a9102bdc577382c3929b337320c4c4c4849f2c5cdd14d7368c5562d",
+                "sha256:d400bfb9a37b1351253cb402671cea7e89bdecc294e8016a707f6d1d8ac934f9",
+                "sha256:d61f4695e6c866a23a21acab0509af1cdfd2c013cf256bbf5b6b5e2695827162",
+                "sha256:db0fbb9c62743ce59a9ff687eb5f4afbe77e5e8403d6697f7446e5f609976f76",
+                "sha256:dd86c085fae2efd48ac91dd7ccffcfc0571387fe1193d33b6394db7ef31fe2a4",
+                "sha256:e00b098126fd45523dd056d2efba6c5a63b71ffe9f2bbe1a4fe1716e1d0c331e",
+                "sha256:e229a521186c75c8ad9490854fd8bbdd9a0c9aa3a524326b55be83b54d4e0ad9",
+                "sha256:e263d77ee3dd201c3a142934a086a4450861778baaeeb45db4591ef65550b0a6",
+                "sha256:ed9cb427ba5504c1dc15ede7d516b84757c3e3d7868ccc85121d9310d27eed0b",
+                "sha256:fa6693661a4c91757f4412306191b6dc88c1703f780c8234035eac011922bc01",
+                "sha256:fcd131dd944808b5bdb38e6f5b53013c5aa4f334c5cad0c72742f6eba4b73db0"
             ],
-            "version": "==1.15.0"
+            "version": "==1.15.1"
         },
         "charset-normalizer": {
             "hashes": [
-                "sha256:e019de665e2bcf9c2b64e2e5aa025fa991da8720daa3c1138cadd2fd1856aed0",
-                "sha256:f7af805c321bfa1ce6714c51f254e0d5bb5e5834039bc17db7ebe3a4cec9492b"
+                "sha256:00d3ffdaafe92a5dc603cb9bd5111aaa36dfa187c8285c543be562e61b755f6b",
+                "sha256:024e606be3ed92216e2b6952ed859d86b4cfa52cd5bc5f050e7dc28f9b43ec42",
+                "sha256:0298eafff88c99982a4cf66ba2efa1128e4ddaca0b05eec4c456bbc7db691d8d",
+                "sha256:02a51034802cbf38db3f89c66fb5d2ec57e6fe7ef2f4a44d070a593c3688667b",
+                "sha256:083c8d17153ecb403e5e1eb76a7ef4babfc2c48d58899c98fcaa04833e7a2f9a",
+                "sha256:0a11e971ed097d24c534c037d298ad32c6ce81a45736d31e0ff0ad37ab437d59",
+                "sha256:0bf2dae5291758b6f84cf923bfaa285632816007db0330002fa1de38bfcb7154",
+                "sha256:0c0a590235ccd933d9892c627dec5bc7511ce6ad6c1011fdf5b11363022746c1",
+                "sha256:0f438ae3532723fb6ead77e7c604be7c8374094ef4ee2c5e03a3a17f1fca256c",
+                "sha256:109487860ef6a328f3eec66f2bf78b0b72400280d8f8ea05f69c51644ba6521a",
+                "sha256:11b53acf2411c3b09e6af37e4b9005cba376c872503c8f28218c7243582df45d",
+                "sha256:12db3b2c533c23ab812c2b25934f60383361f8a376ae272665f8e48b88e8e1c6",
+                "sha256:14e76c0f23218b8f46c4d87018ca2e441535aed3632ca134b10239dfb6dadd6b",
+                "sha256:16a8663d6e281208d78806dbe14ee9903715361cf81f6d4309944e4d1e59ac5b",
+                "sha256:292d5e8ba896bbfd6334b096e34bffb56161c81408d6d036a7dfa6929cff8783",
+                "sha256:2c03cc56021a4bd59be889c2b9257dae13bf55041a3372d3295416f86b295fb5",
+                "sha256:2e396d70bc4ef5325b72b593a72c8979999aa52fb8bcf03f701c1b03e1166918",
+                "sha256:2edb64ee7bf1ed524a1da60cdcd2e1f6e2b4f66ef7c077680739f1641f62f555",
+                "sha256:31a9ddf4718d10ae04d9b18801bd776693487cbb57d74cc3458a7673f6f34639",
+                "sha256:356541bf4381fa35856dafa6a965916e54bed415ad8a24ee6de6e37deccf2786",
+                "sha256:358a7c4cb8ba9b46c453b1dd8d9e431452d5249072e4f56cfda3149f6ab1405e",
+                "sha256:37f8febc8ec50c14f3ec9637505f28e58d4f66752207ea177c1d67df25da5aed",
+                "sha256:39049da0ffb96c8cbb65cbf5c5f3ca3168990adf3551bd1dee10c48fce8ae820",
+                "sha256:39cf9ed17fe3b1bc81f33c9ceb6ce67683ee7526e65fde1447c772afc54a1bb8",
+                "sha256:3ae1de54a77dc0d6d5fcf623290af4266412a7c4be0b1ff7444394f03f5c54e3",
+                "sha256:3b590df687e3c5ee0deef9fc8c547d81986d9a1b56073d82de008744452d6541",
+                "sha256:3e45867f1f2ab0711d60c6c71746ac53537f1684baa699f4f668d4c6f6ce8e14",
+                "sha256:3fc1c4a2ffd64890aebdb3f97e1278b0cc72579a08ca4de8cd2c04799a3a22be",
+                "sha256:4457ea6774b5611f4bed5eaa5df55f70abde42364d498c5134b7ef4c6958e20e",
+                "sha256:44ba614de5361b3e5278e1241fda3dc1838deed864b50a10d7ce92983797fa76",
+                "sha256:4a8fcf28c05c1f6d7e177a9a46a1c52798bfe2ad80681d275b10dcf317deaf0b",
+                "sha256:4b0d02d7102dd0f997580b51edc4cebcf2ab6397a7edf89f1c73b586c614272c",
+                "sha256:502218f52498a36d6bf5ea77081844017bf7982cdbe521ad85e64cabee1b608b",
+                "sha256:503e65837c71b875ecdd733877d852adbc465bd82c768a067badd953bf1bc5a3",
+                "sha256:5995f0164fa7df59db4746112fec3f49c461dd6b31b841873443bdb077c13cfc",
+                "sha256:59e5686dd847347e55dffcc191a96622f016bc0ad89105e24c14e0d6305acbc6",
+                "sha256:601f36512f9e28f029d9481bdaf8e89e5148ac5d89cffd3b05cd533eeb423b59",
+                "sha256:608862a7bf6957f2333fc54ab4399e405baad0163dc9f8d99cb236816db169d4",
+                "sha256:62595ab75873d50d57323a91dd03e6966eb79c41fa834b7a1661ed043b2d404d",
+                "sha256:70990b9c51340e4044cfc394a81f614f3f90d41397104d226f21e66de668730d",
+                "sha256:71140351489970dfe5e60fc621ada3e0f41104a5eddaca47a7acb3c1b851d6d3",
+                "sha256:72966d1b297c741541ca8cf1223ff262a6febe52481af742036a0b296e35fa5a",
+                "sha256:74292fc76c905c0ef095fe11e188a32ebd03bc38f3f3e9bcb85e4e6db177b7ea",
+                "sha256:761e8904c07ad053d285670f36dd94e1b6ab7f16ce62b9805c475b7aa1cffde6",
+                "sha256:772b87914ff1152b92a197ef4ea40efe27a378606c39446ded52c8f80f79702e",
+                "sha256:79909e27e8e4fcc9db4addea88aa63f6423ebb171db091fb4373e3312cb6d603",
+                "sha256:7e189e2e1d3ed2f4aebabd2d5b0f931e883676e51c7624826e0a4e5fe8a0bf24",
+                "sha256:7eb33a30d75562222b64f569c642ff3dc6689e09adda43a082208397f016c39a",
+                "sha256:81d6741ab457d14fdedc215516665050f3822d3e56508921cc7239f8c8e66a58",
+                "sha256:8499ca8f4502af841f68135133d8258f7b32a53a1d594aa98cc52013fff55678",
+                "sha256:84c3990934bae40ea69a82034912ffe5a62c60bbf6ec5bc9691419641d7d5c9a",
+                "sha256:87701167f2a5c930b403e9756fab1d31d4d4da52856143b609e30a1ce7160f3c",
+                "sha256:88600c72ef7587fe1708fd242b385b6ed4b8904976d5da0893e31df8b3480cb6",
+                "sha256:8ac7b6a045b814cf0c47f3623d21ebd88b3e8cf216a14790b455ea7ff0135d18",
+                "sha256:8b8af03d2e37866d023ad0ddea594edefc31e827fee64f8de5611a1dbc373174",
+                "sha256:8c7fe7afa480e3e82eed58e0ca89f751cd14d767638e2550c77a92a9e749c317",
+                "sha256:8eade758719add78ec36dc13201483f8e9b5d940329285edcd5f70c0a9edbd7f",
+                "sha256:911d8a40b2bef5b8bbae2e36a0b103f142ac53557ab421dc16ac4aafee6f53dc",
+                "sha256:93ad6d87ac18e2a90b0fe89df7c65263b9a99a0eb98f0a3d2e079f12a0735837",
+                "sha256:95dea361dd73757c6f1c0a1480ac499952c16ac83f7f5f4f84f0658a01b8ef41",
+                "sha256:9ab77acb98eba3fd2a85cd160851816bfce6871d944d885febf012713f06659c",
+                "sha256:9cb3032517f1627cc012dbc80a8ec976ae76d93ea2b5feaa9d2a5b8882597579",
+                "sha256:9cf4e8ad252f7c38dd1f676b46514f92dc0ebeb0db5552f5f403509705e24753",
+                "sha256:9d9153257a3f70d5f69edf2325357251ed20f772b12e593f3b3377b5f78e7ef8",
+                "sha256:a152f5f33d64a6be73f1d30c9cc82dfc73cec6477ec268e7c6e4c7d23c2d2291",
+                "sha256:a16418ecf1329f71df119e8a65f3aa68004a3f9383821edcb20f0702934d8087",
+                "sha256:a60332922359f920193b1d4826953c507a877b523b2395ad7bc716ddd386d866",
+                "sha256:a8d0fc946c784ff7f7c3742310cc8a57c5c6dc31631269876a88b809dbeff3d3",
+                "sha256:ab5de034a886f616a5668aa5d098af2b5385ed70142090e2a31bcbd0af0fdb3d",
+                "sha256:c22d3fe05ce11d3671297dc8973267daa0f938b93ec716e12e0f6dee81591dc1",
+                "sha256:c2ac1b08635a8cd4e0cbeaf6f5e922085908d48eb05d44c5ae9eabab148512ca",
+                "sha256:c512accbd6ff0270939b9ac214b84fb5ada5f0409c44298361b2f5e13f9aed9e",
+                "sha256:c75ffc45f25324e68ab238cb4b5c0a38cd1c3d7f1fb1f72b5541de469e2247db",
+                "sha256:c95a03c79bbe30eec3ec2b7f076074f4281526724c8685a42872974ef4d36b72",
+                "sha256:cadaeaba78750d58d3cc6ac4d1fd867da6fc73c88156b7a3212a3cd4819d679d",
+                "sha256:cd6056167405314a4dc3c173943f11249fa0f1b204f8b51ed4bde1a9cd1834dc",
+                "sha256:db72b07027db150f468fbada4d85b3b2729a3db39178abf5c543b784c1254539",
+                "sha256:df2c707231459e8a4028eabcd3cfc827befd635b3ef72eada84ab13b52e1574d",
+                "sha256:e62164b50f84e20601c1ff8eb55620d2ad25fb81b59e3cd776a1902527a788af",
+                "sha256:e696f0dd336161fca9adbb846875d40752e6eba585843c768935ba5c9960722b",
+                "sha256:eaa379fcd227ca235d04152ca6704c7cb55564116f8bc52545ff357628e10602",
+                "sha256:ebea339af930f8ca5d7a699b921106c6e29c617fe9606fa7baa043c1cdae326f",
+                "sha256:f4c39b0e3eac288fedc2b43055cfc2ca7a60362d0e5e87a637beac5d801ef478",
+                "sha256:f5057856d21e7586765171eac8b9fc3f7d44ef39425f85dbcccb13b3ebea806c",
+                "sha256:f6f45710b4459401609ebebdbcfb34515da4fc2aa886f95107f556ac69a9147e",
+                "sha256:f97e83fa6c25693c7a35de154681fcc257c1c41b38beb0304b9c4d2d9e164479",
+                "sha256:f9d0c5c045a3ca9bedfc35dca8526798eb91a07aa7a2c0fee134c6c6f321cbd7",
+                "sha256:ff6f3db31555657f3163b15a6b7c6938d08df7adbfc9dd13d9d19edad678f1e8"
             ],
             "markers": "python_version >= '3'",
-            "version": "==2.0.7"
-        },
-        "colorama": {
-            "hashes": [
-                "sha256:5941b2b48a20143d2267e95b1c2a7603ce057ee39fd88e7329b0c292aa16869b",
-                "sha256:9f47eda37229f68eee03b24b9748937c7dc3868f906e8ba69fbcbdd3bc5dc3e2"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.4.4"
+            "version": "==3.0.1"
         },
         "cryptography": {
             "hashes": [
-                "sha256:07bb7fbfb5de0980590ddfc7f13081520def06dc9ed214000ad4372fb4e3c7f6",
-                "sha256:18d90f4711bf63e2fb21e8c8e51ed8189438e6b35a6d996201ebd98a26abbbe6",
-                "sha256:1ed82abf16df40a60942a8c211251ae72858b25b7421ce2497c2eb7a1cee817c",
-                "sha256:22a38e96118a4ce3b97509443feace1d1011d0571fae81fc3ad35f25ba3ea999",
-                "sha256:2d69645f535f4b2c722cfb07a8eab916265545b3475fdb34e0be2f4ee8b0b15e",
-                "sha256:4a2d0e0acc20ede0f06ef7aa58546eee96d2592c00f450c9acb89c5879b61992",
-                "sha256:54b2605e5475944e2213258e0ab8696f4f357a31371e538ef21e8d61c843c28d",
-                "sha256:7075b304cd567694dc692ffc9747f3e9cb393cc4aa4fb7b9f3abd6f5c4e43588",
-                "sha256:7b7ceeff114c31f285528ba8b390d3e9cfa2da17b56f11d366769a807f17cbaa",
-                "sha256:7eba2cebca600a7806b893cb1d541a6e910afa87e97acf2021a22b32da1df52d",
-                "sha256:928185a6d1ccdb816e883f56ebe92e975a262d31cc536429041921f8cb5a62fd",
-                "sha256:9933f28f70d0517686bd7de36166dda42094eac49415459d9bdf5e7df3e0086d",
-                "sha256:a688ebcd08250eab5bb5bca318cc05a8c66de5e4171a65ca51db6bd753ff8953",
-                "sha256:abb5a361d2585bb95012a19ed9b2c8f412c5d723a9836418fab7aaa0243e67d2",
-                "sha256:c10c797ac89c746e488d2ee92bd4abd593615694ee17b2500578b63cad6b93a8",
-                "sha256:ced40344e811d6abba00295ced98c01aecf0c2de39481792d87af4fa58b7b4d6",
-                "sha256:d57e0cdc1b44b6cdf8af1d01807db06886f10177469312fbde8f44ccbb284bc9",
-                "sha256:d99915d6ab265c22873f1b4d6ea5ef462ef797b4140be4c9d8b179915e0985c6",
-                "sha256:eb80e8a1f91e4b7ef8b33041591e6d89b2b8e122d787e87eeb2b08da71bb16ad",
-                "sha256:ebeddd119f526bcf323a89f853afb12e225902a24d29b55fe18dd6fcb2838a76"
+                "sha256:0f8da300b5c8af9f98111ffd512910bc792b4c77392a9523624680f7956a99d4",
+                "sha256:35f7c7d015d474f4011e859e93e789c87d21f6f4880ebdc29896a60403328f1f",
+                "sha256:4789d1e3e257965e960232345002262ede4d094d1a19f4d3b52e48d4d8f3b885",
+                "sha256:5aa67414fcdfa22cf052e640cb5ddc461924a045cacf325cd164e65312d99502",
+                "sha256:5d2d8b87a490bfcd407ed9d49093793d0f75198a35e6eb1a923ce1ee86c62b41",
+                "sha256:6687ef6d0a6497e2b58e7c5b852b53f62142cfa7cd1555795758934da363a965",
+                "sha256:6f8ba7f0328b79f08bdacc3e4e66fb4d7aab0c3584e0bd41328dce5262e26b2e",
+                "sha256:706843b48f9a3f9b9911979761c91541e3d90db1ca905fd63fee540a217698bc",
+                "sha256:807ce09d4434881ca3a7594733669bd834f5b2c6d5c7e36f8c00f691887042ad",
+                "sha256:83e17b26de248c33f3acffb922748151d71827d6021d98c70e6c1a25ddd78505",
+                "sha256:96f1157a7c08b5b189b16b47bc9db2332269d6680a196341bf30046330d15388",
+                "sha256:aec5a6c9864be7df2240c382740fcf3b96928c46604eaa7f3091f58b878c0bb6",
+                "sha256:b0afd054cd42f3d213bf82c629efb1ee5f22eba35bf0eec88ea9ea7304f511a2",
+                "sha256:c5caeb8188c24888c90b5108a441c106f7faa4c4c075a2bcae438c6e8ca73cef",
+                "sha256:ced4e447ae29ca194449a3f1ce132ded8fcab06971ef5f618605aacaa612beac",
+                "sha256:d1f6198ee6d9148405e49887803907fe8962a23e6c6f83ea7d98f1c0de375695",
+                "sha256:e124352fd3db36a9d4a21c1aa27fd5d051e621845cb87fb851c08f4f75ce8be6",
+                "sha256:e422abdec8b5fa8462aa016786680720d78bdce7a30c652b7fadf83a4ba35336",
+                "sha256:ef8b72fa70b348724ff1218267e7f7375b8de4e8194d1636ee60510aae104cd0",
+                "sha256:f0c64d1bd842ca2633e74a1a28033d139368ad959872533b1bab8c80e8240a0c",
+                "sha256:f24077a3b5298a5a06a8e0536e3ea9ec60e4c7ac486755e5fb6e6ea9b3500106",
+                "sha256:fdd188c8a6ef8769f148f88f859884507b954cc64db6b52f66ef199bb9ad660a",
+                "sha256:fe913f20024eb2cb2f323e42a64bdf2911bb9738a15dba7d3cce48151034e3a8"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==35.0.0"
+            "version": "==39.0.1"
         },
         "docutils": {
             "hashes": [
-                "sha256:a31688b2ea858517fa54293e5d5df06fbb875fb1f7e4c64529271b77781ca8fc",
-                "sha256:c1d5dab2b11d16397406a282e53953fe495a46d69ae329f55aa98a5c4e3c5fbb"
+                "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6",
+                "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
-            "version": "==0.18"
+            "markers": "python_version >= '3.7'",
+            "version": "==0.19"
         },
         "idna": {
             "hashes": [
-                "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff",
-                "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"
+                "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
+                "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
-            "markers": "python_version >= '3'",
-            "version": "==3.3"
+            "markers": "python_version >= '3.5'",
+            "version": "==3.4"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:53ccfd5c134223e497627b9815d5030edf77d2ed573922f7a0b8f8bb81a1c100",
-                "sha256:75bdec14c397f528724c1bfd9709d660b33a4d2e77387a3358f20b848bb5e5fb"
+                "sha256:7efb448ec9a5e313a57655d35aa54cd3e01b7e1fbcf72dce1bf06119420f5bad",
+                "sha256:e354bedeb60efa6affdcc8ae121b73544a7aa74156d047311948f6d711cd378d"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==4.8.2"
+            "markers": "python_version >= '3.7'",
+            "version": "==6.0.0"
+        },
+        "jaraco.classes": {
+            "hashes": [
+                "sha256:2353de3288bc6b82120752201c6b1c1a14b058267fa424ed5ce5984e3b922158",
+                "sha256:89559fa5c1d3c34eff6f631ad80bb21f378dbcbb35dd161fd2c6b93f5be2f98a"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==3.2.3"
         },
         "jeepney": {
             "hashes": [
-                "sha256:1b5a0ea5c0e7b166b2f5895b91a08c14de8915afda4407fb5022a195224958ac",
-                "sha256:fa9e232dfa0c498bd0b8a3a73b8d8a31978304dcef0515adc859d4e096f96f4f"
+                "sha256:5efe48d255973902f6badc3ce55e2aa6c5c3b3bc642059ef3a91247bcfcc5806",
+                "sha256:c0a454ad016ca575060802ee4d590dd912e35c122fa04e70306de3d076cce755"
             ],
             "markers": "sys_platform == 'linux'",
-            "version": "==0.7.1"
+            "version": "==0.8.0"
         },
         "keyring": {
             "hashes": [
-                "sha256:6334aee6073db2fb1f30892697b1730105b5e9a77ce7e61fca6b435225493efe",
-                "sha256:bd2145a237ed70c8ce72978b497619ddfcae640b6dcf494402d5143e37755c6e"
+                "sha256:771ed2a91909389ed6148631de678f82ddc73737d85a927f382a8a1b157898cd",
+                "sha256:ba2e15a9b35e21908d0aaf4e0a47acc52d6ae33444df0da2b49d41a46ef6d678"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==23.2.1"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.13.1"
+        },
+        "markdown-it-py": {
+            "hashes": [
+                "sha256:5a35f8d1870171d9acc47b99612dc146129b631baf04970128b568f190d0cc30",
+                "sha256:7c9a5e412688bc771c67432cbfebcdd686c93ce6484913dccf06cb5a0bea35a1"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.2.0"
+        },
+        "mdurl": {
+            "hashes": [
+                "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8",
+                "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.1.2"
+        },
+        "more-itertools": {
+            "hashes": [
+                "sha256:250e83d7e81d0c87ca6bd942e6aeab8cc9daa6096d12c5308f3f92fa5e5c1f41",
+                "sha256:5a6257e40878ef0520b1803990e3e22303a41b5714006c32a3fd8304b26ea1ab"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==9.0.0"
         },
         "packaging": {
             "hashes": [
-                "sha256:096d689d78ca690e4cd8a89568ba06d07ca097e3306a4381635073ca91479966",
-                "sha256:14317396d1e8cdb122989b916fa2c7e9ca8e2be9e8060a6eff75b6b7b4d8a7e0"
+                "sha256:714ac14496c3e68c99c29b00845f7a2b85f3bb6f1078fd9f72fd20f0570002b2",
+                "sha256:b6ad297f8907de0fa2fe1ccbd26fdaf387f5f47c7275fedf8cce89f99446cf97"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==21.2"
-        },
-        "pep517": {
-            "hashes": [
-                "sha256:931378d93d11b298cf511dd634cf5ea4cb249a28ef84160b3247ee9afb4e8ab0",
-                "sha256:dd884c326898e2c6e11f9e0b64940606a93eb10ea022a2e067959f3a110cf161"
-            ],
-            "version": "==0.12.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==23.0"
         },
         "pkginfo": {
             "hashes": [
-                "sha256:37ecd857b47e5f55949c41ed061eb51a0bee97a87c969219d144c0e023982779",
-                "sha256:e7432f81d08adec7297633191bbf0bd47faf13cd8724c3a13250e51d542635bd"
+                "sha256:4b7a555a6d5a22169fcc9cf7bfd78d296b0361adad412a346c1226849af5e546",
+                "sha256:8fd5896e8718a4372f0ea9cc9d96f6417c9b986e23a4d116dda26b62cc29d046"
             ],
-            "version": "==1.7.1"
+            "markers": "python_version >= '3.6'",
+            "version": "==1.9.6"
         },
         "pycparser": {
             "hashes": [
@@ -208,56 +330,67 @@
         },
         "pygments": {
             "hashes": [
-                "sha256:b8e67fe6af78f492b3c4b3e2970c0624cbf08beb1e493b2c99b9fa1b67a20380",
-                "sha256:f398865f7eb6874156579fdf36bc840a03cab64d1cde9e93d68f46a425ec52c6"
+                "sha256:b3ed06a9e8ac9a9aae5a6f5dbe78a8a58655d17b43b93c078f094ddc476ae297",
+                "sha256:fa7bd7bd2771287c0de303af8bfdfc731f51bd2c6a47ab69d117138893b82717"
             ],
-            "markers": "python_version >= '3.5'",
-            "version": "==2.10.0"
+            "markers": "python_version >= '3.6'",
+            "version": "==2.14.0"
         },
-        "pyparsing": {
+        "pyproject-hooks": {
             "hashes": [
-                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
-                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+                "sha256:283c11acd6b928d2f6a7c73fa0d01cb2bdc5f07c57a2eeb6e83d5e56b97976f8",
+                "sha256:f271b298b97f5955d53fb12b72c1fb1948c22c1a6b70b315c54cedaca0264ef5"
             ],
-            "markers": "python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==2.4.7"
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.0"
         },
         "readme-renderer": {
             "hashes": [
-                "sha256:3286806450d9961d6e3b5f8a59f77e61503799aca5155c8d8d40359b4e1e1adc",
-                "sha256:8299700d7a910c304072a7601eafada6712a5b011a20139417e1b1e9f04645d8"
+                "sha256:cd653186dfc73055656f090f227f5cb22a046d7f71a841dfa305f55c9a513273",
+                "sha256:f67a16caedfa71eef48a31b39708637a6f4664c4394801a7b0d6432d13907343"
             ],
-            "version": "==30.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==37.3"
         },
         "requests": {
             "hashes": [
-                "sha256:6c1246513ecd5ecd4528a0906f910e8f0f9c6b8ec72030dc9fd154dc1a6efd24",
-                "sha256:b8aa58f8cf793ffd8782d3d8cb19e66ef36f7aba4353eec859e74678b01b07a7"
+                "sha256:64299f4909223da747622c030b781c0d7811e359c37124b4bd368fb8c6518baa",
+                "sha256:98b1b2782e3c6c4904938b84c0eb932721069dfdb9134313beff7c83c2df24bf"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==2.26.0"
+            "index": "pypi",
+            "version": "==2.28.2"
         },
         "requests-toolbelt": {
             "hashes": [
-                "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f",
-                "sha256:968089d4584ad4ad7c171454f0a5c6dac23971e9472521ea3b6d49d610aa6fc0"
+                "sha256:18565aa58116d9951ac39baa288d3adb5b3ff975c4f25eee78555d89e8f247f7",
+                "sha256:62e09f7ff5ccbda92772a29f394a49c3ad6cb181d568b1337626b2abb628a63d"
             ],
-            "version": "==0.9.1"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.10.1"
         },
         "rfc3986": {
             "hashes": [
-                "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835",
-                "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"
+                "sha256:50b1502b60e289cb37883f3dfd34532b8873c7de9f49bb546641ce9cbd256ebd",
+                "sha256:97aacf9dbd4bfd829baad6e6309fa6573aaf1be3f6fa735c8ab05e46cecb261c"
             ],
-            "version": "==1.5.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.0"
+        },
+        "rich": {
+            "hashes": [
+                "sha256:125d96d20c92b946b983d0d392b84ff945461e5a06d3867e9f9e575f8697b67f",
+                "sha256:8aa57747f3fc3e977684f0176a88e789be314a99f99b43b75d1e9cb5dc6db9e9"
+            ],
+            "markers": "python_full_version >= '3.7.0'",
+            "version": "==13.3.1"
         },
         "secretstorage": {
             "hashes": [
-                "sha256:422d82c36172d88d6a0ed5afdec956514b189ddbfb72fefab0c8a1cee4eaf71f",
-                "sha256:fd666c51a6bf200643495a04abb261f83229dcb6fd8472ec393df7ffc8b6f195"
+                "sha256:2403533ef369eca6d2ba81718576c5e0f564d5cca1b58f73a8b23e7d4eeebd77",
+                "sha256:f356e6628222568e3af06f2eba8df495efa13b3b63081dafd4f7d9a7b7bc9f99"
             ],
             "markers": "sys_platform == 'linux'",
-            "version": "==3.3.1"
+            "version": "==3.3.3"
         },
         "six": {
             "hashes": [
@@ -269,35 +402,27 @@
         },
         "tomli": {
             "hashes": [
-                "sha256:c6ce0015eb38820eaf32b5db832dbc26deb3dd427bd5f6556cf0acac2c214fee",
-                "sha256:f04066f68f5554911363063a30b108d2b5a5b1a010aa8b6132af78489fe3aade"
+                "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
+                "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==1.2.2"
-        },
-        "tqdm": {
-            "hashes": [
-                "sha256:8dd278a422499cd6b727e6ae4061c40b48fce8b76d1ccbf5d34fca9b7f925b0c",
-                "sha256:d359de7217506c9851b7869f3708d8ee53ed70a1b8edbba4dbcb47442592920d"
-            ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
-            "version": "==4.62.3"
+            "markers": "python_version < '3.11'",
+            "version": "==2.0.1"
         },
         "twine": {
             "hashes": [
-                "sha256:218c42324121d4417cbcbbda59c623b8acc4becfce3daa545e6b6dd48bd21385",
-                "sha256:3725b79a6f1cfe84a134544ae1894706e60719ab28547cb6c6de781b9f72706d"
+                "sha256:929bc3c280033347a00f847236564d1c52a3e61b1ac2516c97c48f3ceab756d8",
+                "sha256:9e102ef5fdd5a20661eb88fad46338806c3bd32cf1db729603fe3697b1bc83c8"
             ],
             "index": "pypi",
-            "version": "==3.5.0"
+            "version": "==4.0.2"
         },
         "urllib3": {
             "hashes": [
-                "sha256:4987c65554f7a2dbf30c18fd48778ef124af6fab771a377103da0585e2336ece",
-                "sha256:c4fdf4019605b6e5423637e01bc9fe4daef873709a7973e195ceba0a62bbc844"
+                "sha256:076907bf8fd355cde77728471316625a4d2f7e713c125f51953bb5b3eecf4f72",
+                "sha256:75edcdc2f7d85b137124a6c3c9fc3933cdeaa12ecb9a6a959f22797a0feca7e1"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4' and python_version < '4'",
-            "version": "==1.26.7"
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.26.14"
         },
         "webencodings": {
             "hashes": [
@@ -308,11 +433,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:71c644c5369f4a6e07636f0aa966270449561fcea2e3d6747b8d23efaa9d7832",
-                "sha256:9fe5ea21568a0a70e50f273397638d39b03353731e6cbbb3fd8502a33fec40bc"
+                "sha256:112929ad649da941c23de50f356a2b5570c954b65150642bccdd66bf194d224b",
+                "sha256:48904fc76a60e542af151aded95726c1a5c34ed43ab4134b597665c86d7ad556"
             ],
-            "markers": "python_version >= '3.6'",
-            "version": "==3.6.0"
+            "markers": "python_version >= '3.7'",
+            "version": "==3.15.0"
         }
     },
     "develop": {}

--- a/src/viur_cli/__init__.py
+++ b/src/viur_cli/__init__.py
@@ -8,3 +8,4 @@ from .deploy import *
 from .local import *
 from .vi import *
 from .setup import *
+from .scriptor import scriptor

--- a/src/viur_cli/__init__.py
+++ b/src/viur_cli/__init__.py
@@ -8,4 +8,4 @@ from .deploy import *
 from .local import *
 from .vi import *
 from .setup import *
-from .scriptor import scriptor
+from .scriptor import script

--- a/src/viur_cli/cli.py
+++ b/src/viur_cli/cli.py
@@ -4,6 +4,8 @@ from .conf import *
 from .version import __version__
 
 
+
+
 @click.group(invoke_without_command=True, no_args_is_help=True)
 @click.version_option(__version__)
 @click.pass_context

--- a/src/viur_cli/scriptor/__init__.py
+++ b/src/viur_cli/scriptor/__init__.py
@@ -1,0 +1,1 @@
+from .cli import scriptor

--- a/src/viur_cli/scriptor/__init__.py
+++ b/src/viur_cli/scriptor/__init__.py
@@ -1,1 +1,1 @@
-from .cli import scriptor
+from .cli import script

--- a/src/viur_cli/scriptor/cli.py
+++ b/src/viur_cli/scriptor/cli.py
@@ -2,44 +2,37 @@ import click
 import json
 import requests
 import os
-import re
-import importlib
 import hashlib
 import asyncio
 import sys
-sys.path.append(os.path.dirname(os.path.realpath(__file__)))
-
-import scriptor as scriptor_lib
 import glob
-import tempfile
-import sys
-
-import importlib.util
-from scriptor import Request, init, viur
 from requests.sessions import cookiejar_from_dict
-from getpass import getpass
-from urllib.parse import urlencode
 from weakref import proxy
-
+from .scriptor import Request, init, viur
 from ..cli import cli
 
 
-
 class Config(dict):
-    CONFIG_FILE_NAME = "scriptor_config.json"
+    """
+    Manage scriptor configuration.
+    """
+    CONFIG_FILE_NAME = "viur_scriptor_config.json"
+    DEFAULT_BASE_URL = "http://localhost:8080"
+    DEFAULT_WORKING_DIR = "scripts/"
 
     def __new__(cls):
-        try:
-            cls._instance
-        except AttributeError:
-            cls._instance = None
-
-        if not cls._instance:
+        if not getattr(cls, "_instance", None):
             cls._instance = super().__new__(cls)
+
+            # use defaults in config
+            cls._instance |= {
+                "base_url": cls.DEFAULT_BASE_URL,
+                "working_dir": cls.DEFAULT_WORKING_DIR,
+            }
+
             if os.path.exists(cls.CONFIG_FILE_NAME):
                 with open(cls.CONFIG_FILE_NAME, "r") as f:
-                    for k, v in json.load(f).items():
-                        cls._instance[k] = v
+                    cls._instance |= json.load(f)
 
         return proxy(cls._instance)
 
@@ -56,34 +49,38 @@ class Config(dict):
         self.dump()
 
 
-DEFAULT_BASE_URL = "http://localhost:8080"
-DEFAULT_WORKING_DIR = "scriptor_files/"
+def build_url(url: str):
+    return Config()["base_url"] + "/" + url
+
+viur.request.build_url = staticmethod(build_url)
 
 
 @cli.group()
-def scriptor():
-    pass
+def script():
+    """Manage and run scriptor scripts locally on the console"""
 
 
-@scriptor.command()
-@click.option('--url', default=None, help='Setting the url')
-@click.option('--username', default=None, help='Setting the username')
-@click.option('--working_dir', default=None, help='Setting the working directory')
+@script.command()
+@click.option('--url', default=None, help='Set the url')
+@click.option('--username', default=None, help='Set the username')
+@click.option('--working_dir', default=None, help='Set the working directory where scripts are stored to')
 def configure(url: str, username: str, working_dir: str):
+    conf = Config()
+
     if url:
-        Config()["base_url"] = url
+        conf["base_url"] = url
 
     if username:
-        Config()["username"] = username
+        conf["username"] = username
 
     if working_dir:
-        Config()["working_dir"] = working_dir.replace("\\", "/")
+        conf["working_dir"] = working_dir.replace("\\", "/")
 
 
-@scriptor.command()
+@script.command()
 def setup():
     config = Config()
-    base_url = config.get("base_url", DEFAULT_BASE_URL)
+    base_url = config.get("base_url")
     try:
         session = requests.session()
         skey = session.get(base_url + "/json/skey")
@@ -101,94 +98,84 @@ def setup():
 
         if response.text != "FAILURE":
             config["cookies"] = session.cookies.get_dict()
-            click.echo("Scriptor-cli setup was successfully.")
+            click.echo("Setup done")
         else:
             if "cookies" in config:
                 del config["cookies"]
             click.echo("Failed to login. Did you maybe entered the wrong password?")
     except KeyboardInterrupt:
         pass
-    except:
-        click.echo("Failed to setup scriptor cli.")
 
 
-@scriptor.group()
-@click.pass_context
-def command(ctx: click.Context):
-    base_url = Config().get("base_url", DEFAULT_BASE_URL)
+def check_session(ctx: click.Context):
+    base_url = Config().get("base_url")
 
     s = requests.Session()
     s.cookies = cookiejar_from_dict(Config().get("cookies", {}))
 
     response = s.get(base_url+"/vi/user/view/self", cookies=Config().get("cookies", {}))
     if not response.ok:
-        click.echo("Invalid account session, go to setup again...")
+        click.echo("Invalid session, please run `viur script setup` again.")
         ctx.invoke(setup)
         ctx.close()
 
-
-def build_url(url: str):
-    return Config()["base_url"] + "/" + url
-
-
-viur.request.build_url = staticmethod(build_url)
-
-
-@command.command()
-@click.option('--force', default=False, help='Replacing the files with the new (force)')
-def pull(force: bool):
+@script.command()
+@click.option('--force', default=False, help='Force replace files from server in local working directory')
+@click.pass_context
+def pull(ctx: click.Context, force: bool):
+    check_session(ctx)
     Request.COOKIES = cookiejar_from_dict(Config().get("cookies", {}))
-    from scriptor.module import TreeModule
+    from .scriptor.module import TreeModule
     tree = TreeModule("script")
 
     async def main():
-        try:
-            await tree.structure("node")
-        except:
-            click.echo("Failed to pull... Is the script module included?")
-            return
+        await tree.structure("node")
 
-        working_dir = Config().get("WORKING_DIR", DEFAULT_WORKING_DIR)
-        if working_dir:
-            async def for_each(group: str, entry: object):
-                _path = os.path.join(working_dir, entry["path"])
+        working_dir = Config().get("working_dir")
+        async def for_each(group: str, entry: object):
+            _path = os.path.join(working_dir, entry["path"])
 
-                if group == "node":
-                    if not os.path.exists(_path):
-                        os.makedirs(_path)
-                else:
-                    def create_file():
-                        with open(_path, "a+") as f:
-                            f.write(entry["script"])
+            if group == "node":
+                if not os.path.exists(_path):
+                    os.makedirs(_path)
 
-                    if os.path.exists(_path):
-                        if force:
-                            os.remove(_path)
-                            create_file()
-                        else:
-                            with open(_path, "r") as f:
-                                online_content = entry["script"].replace("\r", "").encode("utf-8")
-                                file_content = f.read().replace("\r", "").encode("utf-8")
-                                if hashlib.sha256(online_content).digest() != hashlib.sha256(file_content).digest():
-                                    if click.confirm(f"There is a difference of this file: {entry['path']}. Do you wanna use it?"):
-                                        os.remove(_path)
-                                        create_file()
+            else:
+                def create_file():
+                    with open(_path, "a+") as f:
+                        f.write(entry["script"])
 
-                    else:
+                    click.echo(f"Pull {_path}")
+
+                if os.path.exists(_path):
+                    if force:
+                        os.remove(_path)
                         create_file()
+                    else:
+                        with open(_path, "r") as f:
+                            online_content = entry["script"].replace("\r", "").encode("utf-8")
+                            file_content = f.read().replace("\r", "").encode("utf-8")
+                            if hashlib.sha256(online_content).digest() != hashlib.sha256(file_content).digest():
+                                if click.confirm(f"There is a difference of this file: {entry['path']}. Do you wanna use it?"):
+                                    os.remove(_path)
+                                    create_file()
 
+                else:
+                    create_file()
 
-            await tree.for_each(for_each)
+        await tree.for_each(for_each)
 
     asyncio.new_event_loop().run_until_complete(main())
 
 
-@command.command()
-@click.option('--force', '-f', is_flag=True, default=False, help='Replacing the files with the new (force)')
-def push(force: bool):
+@script.command()
+@click.option('--force', '-f', is_flag=True, default=False,
+              help='Force push files from the local working directory onto the server')
+@click.pass_context
+def push(ctx: click.Context, force: bool):
+    check_session(ctx)
     Request.COOKIES = cookiejar_from_dict(Config().get("cookies", {}))
 
-    from scriptor.module import TreeModule
+    from .scriptor.module import TreeModule
     tree = TreeModule("script")
 
     async def main():
@@ -198,114 +185,119 @@ def push(force: bool):
             click.echo("Failed to push... Is the script module included?")
             return
 
-        working_dir = Config().get("WORKING_DIR", DEFAULT_WORKING_DIR)
-        if working_dir:
-            _files = glob.glob(f"{working_dir}/**/*", recursive=True)
-            for file in _files:
-                _real_file = file
-                parent = os.path.dirname(file)
-                _type = "leaf"
-                if os.path.isdir(file):
-                    _type = "node"
+        working_dir = Config().get("WORKING_DIR")
+        _files = glob.glob(f"{working_dir}/**/*", recursive=True)
 
-                tmp = working_dir
-                if not working_dir.endswith("/"):
-                    tmp += "/"
-                file = file.removeprefix(tmp)
-                if _type == "node":
-                    file += "/"
+        for file in _files:
+            _real_file = file
+            parent = os.path.dirname(file)
+            _type = "leaf"
+            if os.path.isdir(file):
+                _type = "node"
 
+            tmp = working_dir
+            if not working_dir.endswith("/"):
+                tmp += "/"
+            file = file.removeprefix(tmp)
+            if _type == "node":
+                file += "/"
 
-                is_root = False
-                parent = parent.removeprefix(tmp).removeprefix(working_dir.replace("/", ""))
-                if not parent:
-                    is_root = True
+            is_root = False
+            parent = parent.removeprefix(tmp).removeprefix(working_dir.replace("/", ""))
+            if not parent:
+                is_root = True
 
-                try:
-                    entry = await anext(tree.list(_type, {"path": file}))
-                    if _type == "leaf":
-                        online_content = entry["script"].replace("\r", "").encode("utf-8")
-                        with open(_real_file, "r") as f:
-                            file_content = f.read().replace("\r", "").encode("utf-8")
-                            if hashlib.sha256(online_content).digest() != hashlib.sha256(file_content).digest():
-                                _state = click.confirm(f"The content of the {file} is not up to date, Should we overwrite it?") if not force else True
-                                if _state:
-                                    await tree.edit(_type, entry["key"], {
-                                        "script": file_content
-                                    })
-                except StopAsyncIteration:
-                    _state = False
-                    text = "directory"
-                    if _type == "leaf":
-                        text = "file"
+            try:
+                entry = await anext(tree.list(_type, {"path": file}))
+                if _type == "leaf":
+                    online_content = entry["script"].replace("\r", "").encode("utf-8")
+                    with open(_real_file, "r") as f:
+                        file_content = f.read().replace("\r", "").encode("utf-8")
+                        if hashlib.sha256(online_content).digest() != hashlib.sha256(file_content).digest():
+                            _state = force
+                            if not _state:
+                                _state = click.confirm(f"The content of {file} has changed, override?")
 
-                    _state = click.confirm(f"There is no {text}: '{file}'. Should I create it?") if not force else True
-                    if _state:
-                        root_node_entry = (await tree.list_root_nodes())[0]
-
-                        if not parent.endswith("/"):
-                            parent += "/"
-
-                        parent_entry = root_node_entry
-                        if not is_root:
-                            parent_entry = await anext(tree.list("node", {"path": parent}))
-
-                        last = file
-                        if file.count("/") > 0:
-                            _split = [_f for _f in file.split("/") if _f]
-                            last = _split[len(_split) - 1]
-
-                        args = {
-                            "name": last,
-                            "parentrepo": root_node_entry["key"],
-                            "parententry": parent_entry["key"],
-                            "rootNode": False,
-                            "path": file,
-                            "plugin": False
-                        }
-
-                        if _type != "node":
-                            update_file = False
-                            with open(_real_file, "r") as f:
-                                args.update({
-                                    "script": f.read()
+                            if _state:
+                                click.echo(f"Push {_real_file}")
+                                await tree.edit(_type, entry["key"], {
+                                    "script": file_content
                                 })
 
-                                if not args["script"]:
-                                    args["script"] = "#### scriptor ####"
-                                    update_file = True
-                            if update_file:
-                                with open(_real_file, "w") as f:
-                                    f.truncate()
-                                    f.write(args["script"])
+            except StopAsyncIteration:
+                _state = False
+                text = "folder"
+                if _type == "leaf":
+                    text = "file"
 
-                        await tree.add(_type, args)
+                _state = force
+                if not _state:
+                    _state = click.confirm(f"There is no {text} named {file}. Create it?")
+
+                if _state:
+                    root_node_entry = (await tree.list_root_nodes())[0]
+
+                    if not parent.endswith("/"):
+                        parent += "/"
+
+                    parent_entry = root_node_entry
+                    if not is_root:
+                        parent_entry = await anext(tree.list("node", {"path": parent}))
+
+                    last = file
+                    if file.count("/") > 0:
+                        _split = [_f for _f in file.split("/") if _f]
+                        last = _split[len(_split) - 1]
+
+                    args = {
+                        "name": last,
+                        "parentrepo": root_node_entry["key"],
+                        "parententry": parent_entry["key"],
+                        "rootNode": False,
+                        "path": file,
+                        "plugin": False
+                    }
+
+                    if _type != "node":
+                        update_file = False
+                        with open(_real_file, "r") as f:
+                            args.update({
+                                "script": f.read()
+                            })
+
+                            if not args["script"]:
+                                args["script"] = "#### scriptor ####"
+                                update_file = True
+                        if update_file:
+                            with open(_real_file, "w") as f:
+                                f.truncate()
+                                f.write(args["script"])
+
+                    click.echo(f"Push {_real_file}")
+                    await tree.add(_type, args)
 
     asyncio.new_event_loop().run_until_complete(main())
 
 
-@command.command()
-@click.option('--path', help='Path of the file in the working directory')
-def run(path: str):
+@script.command()
+@click.argument('path', required=True)
+@click.pass_context
+def run(ctx: click.Context, path: str):
+    check_session(ctx)
     Request.COOKIES = cookiejar_from_dict(Config().get("cookies", {}))
 
-    if not path:
-        click.echo("You need to enter a file path to execute.")
-        return
-
-    working_dir = Config().get("WORKING_DIR", DEFAULT_WORKING_DIR)
-    sys.path.append(working_dir)
-    _file_path = os.path.join(working_dir, path)
-    _file_path = _file_path.replace("/", ".")
+    for dir in (os.path.dirname(os.path.realpath(__file__)), Config().get("working_dir")):
+        if dir not in sys.path:
+            sys.path.insert(0, dir)
 
     async def main():
         await init()
         import logging
-        logging.getLogger().setLevel(logging.INFO)
         import importlib
-        p = path.replace(".py", "")
-        p = p.replace("/", ".")
-        module = importlib.import_module(p)
+        logging.getLogger().setLevel(logging.INFO)
+        module = importlib.import_module(path.removesuffix(".py"))
+        print(module)
+        print(module.__file__)
         await module.main()
 
     asyncio.new_event_loop().run_until_complete(main())

--- a/src/viur_cli/scriptor/cli.py
+++ b/src/viur_cli/scriptor/cli.py
@@ -1,0 +1,314 @@
+import click
+import json
+import requests
+import os
+import re
+import importlib
+import hashlib
+import asyncio
+import sys
+sys.path.append(os.path.dirname(os.path.realpath(__file__)))
+
+import scriptor as scriptor_lib
+import glob
+import tempfile
+import sys
+
+import importlib.util
+from scriptor import Request, init, viur
+from requests.sessions import cookiejar_from_dict
+from getpass import getpass
+from urllib.parse import urlencode
+from weakref import proxy
+
+from ..cli import cli
+
+
+
+class Config(dict):
+    CONFIG_FILE_NAME = "scriptor_config.json"
+
+    def __new__(cls):
+        try:
+            cls._instance
+        except AttributeError:
+            cls._instance = None
+
+        if not cls._instance:
+            cls._instance = super().__new__(cls)
+            if os.path.exists(cls.CONFIG_FILE_NAME):
+                with open(cls.CONFIG_FILE_NAME, "r") as f:
+                    for k, v in json.load(f).items():
+                        cls._instance[k] = v
+
+        return proxy(cls._instance)
+
+    def dump(self):
+        with open(self.CONFIG_FILE_NAME, "w") as f:
+            json.dump(self, f)
+
+    def __setitem__(self, __key: str, __value: object) -> None:
+        super().__setitem__(__key, __value)
+        self.dump()
+
+    def __delitem__(self, __key: str) -> None:
+        super().__delitem__(__key)
+        self.dump()
+
+
+DEFAULT_BASE_URL = "http://localhost:8080"
+DEFAULT_WORKING_DIR = "scriptor_files/"
+
+
+@cli.group()
+def scriptor():
+    pass
+
+
+@scriptor.command()
+@click.option('--url', default=None, help='Setting the url')
+@click.option('--username', default=None, help='Setting the username')
+@click.option('--working_dir', default=None, help='Setting the working directory')
+def configure(url: str, username: str, working_dir: str):
+    if url:
+        Config()["base_url"] = url
+
+    if username:
+        Config()["username"] = username
+
+    if working_dir:
+        Config()["working_dir"] = working_dir.replace("\\", "/")
+
+
+@scriptor.command()
+def setup():
+    config = Config()
+    base_url = config.get("base_url", DEFAULT_BASE_URL)
+    try:
+        session = requests.session()
+        skey = session.get(base_url + "/json/skey")
+        username: str = config.get("username", "")
+        if not username:
+            username = click.prompt("Enter the username")
+
+        password: str = click.prompt("Enter the password", hide_input=True)
+
+        response = session.post(base_url + "/vi/user/auth_userpassword/login", data={
+            "skey": skey.json(),
+            "name": username,
+            "password": password
+        })
+
+        if response.text != "FAILURE":
+            config["cookies"] = session.cookies.get_dict()
+            click.echo("Scriptor-cli setup was successfully.")
+        else:
+            if "cookies" in config:
+                del config["cookies"]
+            click.echo("Failed to login. Did you maybe entered the wrong password?")
+    except KeyboardInterrupt:
+        pass
+    except:
+        click.echo("Failed to setup scriptor cli.")
+
+
+@scriptor.group()
+@click.pass_context
+def command(ctx: click.Context):
+    base_url = Config().get("base_url", DEFAULT_BASE_URL)
+
+    s = requests.Session()
+    s.cookies = cookiejar_from_dict(Config().get("cookies", {}))
+
+    response = s.get(base_url+"/vi/user/view/self", cookies=Config().get("cookies", {}))
+    if not response.ok:
+        click.echo("Invalid account session, go to setup again...")
+        ctx.invoke(setup)
+        ctx.close()
+
+
+def build_url(url: str):
+    return Config()["base_url"] + "/" + url
+
+
+viur.request.build_url = staticmethod(build_url)
+
+
+@command.command()
+@click.option('--force', default=False, help='Replacing the files with the new (force)')
+def pull(force: bool):
+    Request.COOKIES = cookiejar_from_dict(Config().get("cookies", {}))
+    from scriptor.module import TreeModule
+    tree = TreeModule("script")
+
+    async def main():
+        try:
+            await tree.structure("node")
+        except:
+            click.echo("Failed to pull... Is the script module included?")
+            return
+
+        working_dir = Config().get("WORKING_DIR", DEFAULT_WORKING_DIR)
+        if working_dir:
+            async def for_each(group: str, entry: object):
+                _path = os.path.join(working_dir, entry["path"])
+
+                if group == "node":
+                    if not os.path.exists(_path):
+                        os.makedirs(_path)
+                else:
+                    def create_file():
+                        with open(_path, "a+") as f:
+                            f.write(entry["script"])
+
+                    if os.path.exists(_path):
+                        if force:
+                            os.remove(_path)
+                            create_file()
+                        else:
+                            with open(_path, "r") as f:
+                                online_content = entry["script"].replace("\r", "").encode("utf-8")
+                                file_content = f.read().replace("\r", "").encode("utf-8")
+                                if hashlib.sha256(online_content).digest() != hashlib.sha256(file_content).digest():
+                                    if click.confirm(f"There is a difference of this file: {entry['path']}. Do you wanna use it?"):
+                                        os.remove(_path)
+                                        create_file()
+
+                    else:
+                        create_file()
+
+
+            await tree.for_each(for_each)
+
+    asyncio.new_event_loop().run_until_complete(main())
+
+
+@command.command()
+@click.option('--force', '-f', is_flag=True, default=False, help='Replacing the files with the new (force)')
+def push(force: bool):
+    Request.COOKIES = cookiejar_from_dict(Config().get("cookies", {}))
+
+    from scriptor.module import TreeModule
+    tree = TreeModule("script")
+
+    async def main():
+        try:
+            await tree.structure("node")
+        except:
+            click.echo("Failed to push... Is the script module included?")
+            return
+
+        working_dir = Config().get("WORKING_DIR", DEFAULT_WORKING_DIR)
+        if working_dir:
+            _files = glob.glob(f"{working_dir}/**/*", recursive=True)
+            for file in _files:
+                _real_file = file
+                parent = os.path.dirname(file)
+                _type = "leaf"
+                if os.path.isdir(file):
+                    _type = "node"
+
+                tmp = working_dir
+                if not working_dir.endswith("/"):
+                    tmp += "/"
+                file = file.removeprefix(tmp)
+                if _type == "node":
+                    file += "/"
+
+
+                is_root = False
+                parent = parent.removeprefix(tmp).removeprefix(working_dir.replace("/", ""))
+                if not parent:
+                    is_root = True
+
+                try:
+                    entry = await anext(tree.list(_type, {"path": file}))
+                    if _type == "leaf":
+                        online_content = entry["script"].replace("\r", "").encode("utf-8")
+                        with open(_real_file, "r") as f:
+                            file_content = f.read().replace("\r", "").encode("utf-8")
+                            if hashlib.sha256(online_content).digest() != hashlib.sha256(file_content).digest():
+                                _state = click.confirm(f"The content of the {file} is not up to date, Should we overwrite it?") if not force else True
+                                if _state:
+                                    await tree.edit(_type, entry["key"], {
+                                        "script": file_content
+                                    })
+                except StopAsyncIteration:
+                    _state = False
+                    text = "directory"
+                    if _type == "leaf":
+                        text = "file"
+
+                    _state = click.confirm(f"There is no {text}: '{file}'. Should I create it?") if not force else True
+                    if _state:
+                        root_node_entry = (await tree.list_root_nodes())[0]
+
+                        if not parent.endswith("/"):
+                            parent += "/"
+
+                        parent_entry = root_node_entry
+                        if not is_root:
+                            parent_entry = await anext(tree.list("node", {"path": parent}))
+
+                        last = file
+                        if file.count("/") > 0:
+                            _split = [_f for _f in file.split("/") if _f]
+                            last = _split[len(_split) - 1]
+
+                        args = {
+                            "name": last,
+                            "parentrepo": root_node_entry["key"],
+                            "parententry": parent_entry["key"],
+                            "rootNode": False,
+                            "path": file,
+                            "plugin": False
+                        }
+
+                        if _type != "node":
+                            update_file = False
+                            with open(_real_file, "r") as f:
+                                args.update({
+                                    "script": f.read()
+                                })
+
+                                if not args["script"]:
+                                    args["script"] = "#### scriptor ####"
+                                    update_file = True
+                            if update_file:
+                                with open(_real_file, "w") as f:
+                                    f.truncate()
+                                    f.write(args["script"])
+
+                        await tree.add(_type, args)
+
+    asyncio.new_event_loop().run_until_complete(main())
+
+
+@command.command()
+@click.option('--path', help='Path of the file in the working directory')
+def run(path: str):
+    Request.COOKIES = cookiejar_from_dict(Config().get("cookies", {}))
+
+    if not path:
+        click.echo("You need to enter a file path to execute.")
+        return
+
+    working_dir = Config().get("WORKING_DIR", DEFAULT_WORKING_DIR)
+    sys.path.append(working_dir)
+    _file_path = os.path.join(working_dir, path)
+    _file_path = _file_path.replace("/", ".")
+
+    async def main():
+        await init()
+        import logging
+        logging.getLogger().setLevel(logging.INFO)
+        import importlib
+        p = path.replace(".py", "")
+        p = p.replace("/", ".")
+        module = importlib.import_module(p)
+        await module.main()
+
+    asyncio.new_event_loop().run_until_complete(main())
+
+
+

--- a/src/viur_cli/scriptor/scriptor/__init__.py
+++ b/src/viur_cli/scriptor/scriptor/__init__.py
@@ -1,0 +1,53 @@
+import asyncio
+
+from .utils import get_json_object, is_pyodide_context
+
+
+
+from .network import Request
+from .viur import viur
+from .csvwriter import MemoryCsvWriter, FileSystemCsvWriter
+from .logger import Logging as logging
+from .module import ListModule, SingletonModule, TreeModule
+
+from .writer import DirectoryPickerWriter, FilePickerWriter, MemoryWriter
+from .readers import FilePickerReader
+
+try:
+	from js import console
+except ModuleNotFoundError:
+	pass
+
+
+import json
+import copy
+
+old_print = print
+
+def print(*args, **kwargs):
+	if is_pyodide_context():
+		logging.info(*args, **kwargs)
+	else:
+		old_print(logging.format_text(*args, **kwargs))
+
+
+from .utils import sleep
+
+class prototypes:
+	list = ListModule
+	singleton = SingletonModule
+	tree = TreeModule
+
+
+viur.prototypes = prototypes()
+
+try:
+	viur.modules
+except AttributeError:
+	viur.modules = []
+
+async def init():
+	resp = await viur.request.get("/config", renderer="vi")
+	viur.modules = resp["modules"]
+	if is_pyodide_context():
+		console.log("response = ", resp)

--- a/src/viur_cli/scriptor/scriptor/csvwriter.py
+++ b/src/viur_cli/scriptor/scriptor/csvwriter.py
@@ -1,0 +1,131 @@
+from .writer import MemoryWriter, DirectoryPickerWriter
+from .utils import is_pyodide_context
+
+if is_pyodide_context():
+	from js import console
+
+import csv
+import json
+
+
+class MemoryCsvWriter(MemoryWriter):
+	"""
+	Writer for CSV exports
+	"""
+
+	DEFAULT_FILE_NAME = "export.csv"
+
+	def __init__(self, *args, delimiter=";", formatter: callable = None):
+		super().__init__()
+		self._content.write("\ufeff")  # excel needs this for right utf-8 decoding
+
+		if args:
+			self._writer = csv.DictWriter(
+				self._content,
+				fieldnames=args,
+				extrasaction="ignore",
+				delimiter=delimiter,
+				dialect="excel",
+				quoting=csv.QUOTE_ALL
+			)
+			self._writer.writeheader()
+		else:
+			self._writer = csv.writer(
+				self._content,
+				delimiter=delimiter,
+				dialect="excel",
+				quoting=csv.QUOTE_ALL
+			)
+
+		self._formatter: callable = formatter
+
+
+	@property
+	def writer(self):
+		return self._writer
+
+	@writer.setter
+	def writer(self, writer: csv.DictWriter):
+		self._writer = writer
+
+	def fmt(self, value):
+		if self._formatter:
+			ret = self._formatter(value)
+			if ret is not None:
+				return ret
+
+		if isinstance(value, list):
+			ret = ", ".join([self.fmt(v) for v in value])
+			if is_pyodide_context():
+				console.log(ret)
+			else:
+				print(ret)
+			return ret
+		elif isinstance(value, dict):
+			return json.dumps(value, sort_keys=True)
+
+		return str(value)
+
+	async def write(self, values: object):
+		if isinstance(values, dict):
+			assert isinstance(self._writer, csv.DictWriter)
+			self._writer.writerow({k: self.fmt(v) for k, v in values.items() if k in self._writer.fieldnames})
+			self._line_count += 1
+		elif isinstance(values, list):
+			if isinstance(self._writer, csv.DictWriter):
+				for row in values:
+					self.write(row)
+			else:
+				self._writer.writerow([self.fmt(v) for v in values])
+				self._line_count += 1
+		else:
+			raise NotImplementedError(f"Don't know what to do with {repr(values)}")
+
+
+	def __str__(self):
+		return self._content.getvalue()
+
+class FileSystemCsvWriter(MemoryCsvWriter):
+	"""
+	Writer for CSV exports
+	"""
+
+	DEFAULT_FILE_NAME = "export.csv"
+
+	def __init__(self, *args, delimiter=";", formatter: callable = None, on_startup: callable = None):
+		super().__init__(*args, delimiter=delimiter, formatter=formatter)
+
+		if len(args) > 0:
+			self.clear()
+
+		self._directory_writer = None
+		self._on_startup = on_startup
+		self._file = None
+		
+
+	async def init(self):
+		await DirectoryPickerWriter.from_dialog(self.startup)
+	
+	async def startup(self, handle):
+		await self._on_startup(handle)
+
+	async def write(self, values: object):
+		if isinstance(values, dict):
+			assert isinstance(self._writer, csv.DictWriter)
+			self._writer.writerow({k: self.fmt(v) for k, v in values.items() if k in self._writer.fieldnames})
+			self.clear()
+			self._line_count += 1
+		elif isinstance(values, list):
+			if isinstance(self._writer, csv.DictWriter):
+				for row in values:
+					self.write(row)
+			else:
+				self._writer.writerow([self.fmt(v) for v in values])
+
+				if self._file:
+					self._file.write(str(self))
+
+				self.clear()
+				self._line_count += 1
+		else:
+			raise NotImplementedError(f"Don't know what to do with {repr(values)}")

--- a/src/viur_cli/scriptor/scriptor/dialog.py
+++ b/src/viur_cli/scriptor/scriptor/dialog.py
@@ -1,0 +1,211 @@
+from .utils import is_pyodide_context
+
+if is_pyodide_context():
+    from js import eval as js_eval, self as _self, Blob
+    from js import console
+
+    import manager
+else:
+    import asyncio
+    import click
+
+import time
+import datetime
+import time
+import math
+
+async def wait():
+    if is_pyodide_context():
+        while manager.resultValue is None:
+            await manager.sleep(250)
+    else:
+        await asyncio.sleep(250)
+
+async def alert(text: str):
+    if is_pyodide_context():
+        _self.postMessage(type="alert", text=text)
+        await wait();
+        manager.reset()
+        manager.resultValue = None
+    else:
+        click.prompt("Press a key")
+        
+
+async def confirm(title: str, text: str, cancel: bool = False) -> str:
+    if is_pyodide_context():
+        _self.postMessage(type="confirm", title=title, text=text, cancel=cancel)
+        await wait(); 
+        tmp = manager.copyResult()
+        manager.reset()
+        manager.resultValue = None
+
+        return tmp
+    else:
+        value = 0
+        try:
+            value = int(click.confirm(text, abort=True))
+        except:
+            value = -1
+        return value
+
+
+# time = true
+# datetim-picker local
+
+
+async def input(title: str, text: str, type: str, use_time: bool = False, empty: bool = False):
+    if is_pyodide_context():
+        _self.postMessage(type="input", title=title, text=text, input_type=type, use_time=use_time, empty=empty)
+        await wait(); 
+        tmp = manager.copyResult()
+        manager.reset()
+        manager.resultValue = None
+
+        if type == "date":
+            console.error(tmp)
+            return datetime.datetime.fromtimestamp(math.floor(tmp/1000.0))
+        
+        return tmp
+    else:
+        click.echo(title)
+        ret = click.prompt(text)
+        if type == "date":
+            def validate_date(date_text):
+                try:
+                    return datetime.date.fromisoformat(date_text)
+                except ValueError:
+                    click.echo("Incorrect data format, should be YYYY-MM-DD")
+
+            
+                return None
+
+            def validate_datetime(date_text):
+                try:
+                    return datetime.datetime.fromisoformat(date_text)
+                except ValueError:
+                    click.echo("Incorrect data format, should be YYYY-MM-DD HH:MM:SS")
+            
+                return None
+ 
+            if use_time:
+                while not validate_date(ret):
+                    ret = click.prompt(text)
+            else:
+                while not validate_datetime(ret):
+                    ret = click.prompt(text)
+            
+            return ret
+        elif type == "number":
+            def check_number(value: str):
+                try:
+                    r = float(value.replace("," "."))
+                    return ret
+                except:
+                    try:
+                        r = int(value)
+                        return r
+                    except:
+                        return None
+                return None
+            while True:
+                ret = check_number(ret)
+                if ret is None:
+                    click.echo("Enter a valid number.")
+                    ret = click.prompt(text)
+                else:
+                    break
+
+            return ret
+        else:
+            return ret
+
+async def input_date(*args, **kwargs):
+    kwargs.update({"type": "date"})
+    return await input(*args, **kwargs)
+
+async def input_number(*args, **kwargs):
+    kwargs.update({"type": "number"})
+    return await input(*args, **kwargs)
+
+async def input_string(*args, **kwargs):
+    kwargs.update({"type": "string"})
+    return await input(*args, **kwargs)
+
+async def input_text(*args, **kwargs):
+    kwargs.update({"type": "text"})
+    return await input(*args, **kwargs)
+
+input.date = input_date
+input.number = input_number
+input.text = input_text
+input.string = input_string
+
+if is_pyodide_context():
+    from pyodide.ffi import to_js
+
+
+async def select(title: str, text: str, choices: list[int], multiple: bool = False):
+
+    _choices = choices
+    if is_pyodide_context():
+        _choices = to_js(_choices)
+
+        _self.postMessage(type="select", title=title, text=text, choices=_choices, multiple=multiple)
+        await wait(); 
+
+        tmp = manager.resultValue
+        if multiple:
+            tmp = list(tmp)
+        manager.reset()
+        manager.resultValue = None
+
+        return tmp
+    else:
+        click.echo(title)
+        text += "\n\n"
+        for i, _ in enumerate(choices):
+            text += str(choices[i]) + (", " if i != len(choices)-1 else "")
+            if i > 0 and i % 3 == 0:
+                text += "\n"
+            
+        lower_choices = [e.lower() for e in choices]
+        result_value = -1
+        while True:
+            _ret = click.prompt(text)
+            if not multiple:
+                if _ret.lower() in lower_choices:
+                    result_value = lower_choices.index(_ret.lower())
+                    break
+                else:
+                    click.echo("You entered a invalid input!")
+            else:
+                if _ret.find(",") == -1:
+                    if _ret.lower() in lower_choices:
+                        result_value = [lower_choices.index(_ret.lower()), ]
+                        break
+                    else:
+                        click.echo("You entered a invalid input!")
+
+                else:
+                    result = _ret.split(",")
+                    valid = True
+                    result_value = []
+                    for res in result:
+                        _tmp = res.lower().lstrip()
+                        if not (_tmp in lower_choices):
+                            valid = False
+                            break
+                        result_value.append(lower_choices.index(_tmp))
+
+                    if not valid:
+                        click.echo("You entered a invalid input!")
+                        continue
+                    break
+
+        return result_value
+
+
+
+    return None
+
+

--- a/src/viur_cli/scriptor/scriptor/logger.py
+++ b/src/viur_cli/scriptor/scriptor/logger.py
@@ -1,0 +1,80 @@
+from .utils import is_pyodide_context
+
+if is_pyodide_context():
+	from js import self as _self
+else:
+	import logging
+
+import json
+
+class Logging():
+	CRITICAL = 50
+	FATAL = CRITICAL
+	ERROR = 40
+	WARNING = 30
+	WARN = WARNING
+	INFO = 20
+	DEBUG = 10
+	NOTSET = 0
+
+	@staticmethod
+	def format_text(*args, **kwargs):
+		jsonify = False
+		if any([isinstance(arg, (dict, list)) for arg in args]):
+			jsonify = True
+
+		text = ""
+		if jsonify:
+			try:
+				if is_pyodide_context():
+					text = json.dumps(args)
+				else:
+					text = json.dumps(args, sort_keys=True, indent=4)
+			except:
+				text = ""
+
+		if not text:
+			delimiter = kwargs.get("sep", " ")
+			text = f"{delimiter}".join([str(arg) for arg in args])
+
+		return text
+	
+	@staticmethod
+	def set_level(level: int):
+		if not is_pyodide_context():
+			logging.getLogger().setLevel(level)
+
+	@staticmethod
+	def debug(*args, **kwargs):
+		text=Logging.format_text(*args, **kwargs)
+		if is_pyodide_context():
+			_self.postMessage(type="log", text=text, level="debug")
+		else:
+			logging.debug(text)
+
+	@staticmethod
+	def info(*args, **kwargs):
+		text=Logging.format_text(*args, **kwargs)
+		if is_pyodide_context():
+			_self.postMessage(type="log", text=text, level="info")
+		else:
+			logging.info(text)
+
+	@staticmethod
+	def warning(*args, **kwargs):
+		text=Logging.format_text(*args, **kwargs)
+
+		if is_pyodide_context():
+			_self.postMessage(type="log", text=text, level="warning")
+		else:
+			logging.warning(text)
+
+	@staticmethod
+	def error(*args, **kwargs):
+		text=Logging.format_text(*args, **kwargs)
+
+		if is_pyodide_context():
+			_self.postMessage(type="log", text=Logging.format_text(*args, **kwargs), level="error")
+		else:
+			logging.error(text)
+

--- a/src/viur_cli/scriptor/scriptor/module.py
+++ b/src/viur_cli/scriptor/scriptor/module.py
@@ -1,0 +1,166 @@
+from .viur import viur
+from .network import Request
+from .viur import viur
+from .utils import is_pyodide_context
+if is_pyodide_context():
+	from js import console
+
+import inspect
+
+class BaseModule(object):
+	def __init__(self, name: str):
+		self._name = name
+		self._routes = {}
+
+	@property
+	def name(self) -> str:
+		return self._name
+
+	@name.setter
+	def name(self, value: str):
+		self._name = value
+
+	async def register_route(self, callback: callable, name: str = None):
+		self._routes[name if name is not None else callback.__name__] = {"function": callback,"instance": None}
+
+	async def register_routes(self, route: object):
+		functions = inspect.getmembers(route.__class__, predicate=inspect.isfunction)
+		for name, func in functions:
+			if is_pyodide_context():
+				console.log(f"Register route name {name}")
+
+			if name.startswith("__"):
+				continue
+
+			if is_pyodide_context():
+				console.log(f"Register route {name} -> {func}")
+			async def wrap(*args, **kwargs):
+				return await func(self._routes[name]["instance"], *args, **kwargs)
+
+			self._routes[name] = {
+				"function": wrap,
+				"instance": route
+			}
+
+	def __getattr__(self, name: str):
+		if ret := self._routes.get(name, None):
+			return ret["function"]
+		return self.__getattribute__(name)
+
+
+	async def preview(self, params: dict = None, group: str = ""):
+		return await viur.preview(module=self._name, params=params, group=group)
+
+	async def structure(self, group: str = ""):
+		return await viur.structure(module=self._name, group=group)
+
+	async def view(self, key: str, group: str = "") -> dict:
+		return await viur.view(module=self._name, key=key, group=group)
+
+class SingletonModule(BaseModule):
+	async def edit(self, params: dict = None, group: str = ""):
+		return await viur.edit(module=self._name, params=params, group=group)
+
+class ExtendedModule(BaseModule):
+	async def edit(self, key: str, params: dict = None, group: str = ""):
+		return await viur.edit(module=self._name, key=key, params=params, group=group)
+
+	def list(self, params: dict = None, group: str = '') -> viur.list:
+		return viur.list(module=self._name, params=params, group=group)
+
+	async def add(self, params: dict = None, group: str = ""):
+		return await viur.add(module=self._name, params=params, group=group)
+
+	async def delete(self, key: str, params: dict = None, group: str = ""):
+		return await viur.delete(module=self._name, key=key, params=params, group=group)
+
+
+class ListModule(ExtendedModule):
+	async def for_each(self, callback: callable, params: dict = None):
+		async for entry in self.list(params=params):
+			await callback(entry)
+
+class TreeModule(ExtendedModule):
+	async def edit(self, group: str, key: str, params: dict = None):
+		return await super().edit(group=group, key=key, params=params)
+
+	def list(self, group: str, params: dict = None) -> viur.list:
+		return super().list(group=group, params=params)
+
+	async def add(self, group: str, params: dict = None):
+		return await super().add(group=group, params=params)
+
+	async def view(self, group: str, key: str) -> dict:
+		return await super().view(group=group, key=key)
+
+	async def preview(self, group: str, params: dict = None):
+		return await super().preview(params=params, group=group)
+	
+
+	async def list_root_nodes(self):
+		return await viur.request.get(f"/{self.name}/listRootNodes")
+
+	async def delete(self, group: str, key: str, params: dict = None):
+		return await super().delete(group=group, key=key, params=params)
+
+	async def move(self, key: str, parentNode: str):
+		return await viur.request.secure_post(f"/{self.name}/move", params={
+			"key": key,
+			"parentNode": parentNode
+		})
+
+	async def for_each(self, callback: callable, root_node_key: str = None, params: dict = None):
+		##
+		async def download(key: str, group: str|list[str] = ['node', 'leaf']):
+			if isinstance(group, list):
+				for grp in group:
+					await download(key, grp)
+				return
+			
+			_params = {"parententry": key}
+			if params:
+				_params.update(params)
+
+
+			async for entry in self.list(group, _params):
+				await callback(group, entry)
+				# Check if this is a node
+				if group == "node":
+					await download(entry["key"])
+
+		if root_node_key:
+			root_nodes = [root_node_key]
+		else:
+			root_nodes = await self.list_root_nodes()
+	
+		for root_node in root_nodes:
+			await download(root_node["key"])
+
+
+def __getattr__(attr):
+	modules_resolver = {
+		"tree": TreeModule, 
+		"list": ListModule,
+		"singleton": SingletonModule
+	}
+
+	details = viur.modules.get(attr, None)
+	if details:
+		module_type = None
+		for key, value in modules_resolver.items():
+			if details["handler"].startswith(key):
+				module_type = value
+				break
+		
+		# If the module has a registered type
+		if module_type:
+			# Ensure one instance of the module
+			if not ("type" in details):
+				details["type"] = module_type
+
+			if not ("instance" in details):
+				details["instance"] = details["type"](attr)
+
+			return details["instance"]
+
+	return super(__import__(__name__).__class__).__getattr__(attr)

--- a/src/viur_cli/scriptor/scriptor/network.py
+++ b/src/viur_cli/scriptor/scriptor/network.py
@@ -1,0 +1,127 @@
+import json
+
+from urllib.parse import urlencode as _urlencode
+from .utils import is_pyodide_context
+from abc import abstractmethod
+
+if is_pyodide_context():
+    from js import console, fetch, FormData
+    from pyodide.ffi import to_js
+    from config import BASE_URL
+else:
+    import requests
+    from requests.sessions import cookiejar_from_dict
+
+from .logger import Logging
+
+
+class Request:
+    COOKIES = {}
+
+    def __init__(self, method: str, url: str, credentials: bool = False, headers: dict = None, data: dict = None) -> None:
+        self._status = None
+        self._result = None
+
+        self._method = method.upper()
+        self._data = None
+        self._credentials = credentials
+
+        if data:
+            if method == "GET":
+                url += "?" + _urlencode(data)
+            else:
+                if is_pyodide_context():
+                    self._data = FormData.new()
+                    for k, v in data.items():
+                        self._data.append(k, v)
+                else:
+                    self._data = data
+
+        self._headers = headers
+        self._url = url
+        self._response = None
+
+    async def perform(self):
+        if is_pyodide_context():
+            options = {"method": self._method}
+
+            if self._headers:
+                options.update({"headers": to_js(self._headers)})
+            
+            if self._data:
+                options.update({"body": to_js(self._data)})
+
+            if self._credentials:
+                options.update({"credentials": 'include'})
+
+            self._response = await fetch(self._url, **options)
+            self._status = self._response.status
+        else:
+            kwargs = {"headers":self._headers}
+            if self._method == "POST":
+                kwargs.update({"data": self._data})
+                        
+            try:
+                if self._credentials:
+                    kwargs.update({"cookies": self.COOKIES})
+            except AttributeError:
+                Logging.error("You need to set an cookie.")
+
+            self._response = requests.request(self._method, self._url, **kwargs)
+            self._status = self._response.status_code
+    
+    async def json(self):
+        if not self._response:
+            return None
+
+        if is_pyodide_context():
+            return json.loads(await self._response.text())
+
+        return self._response.json()
+
+    async def text(self):
+        if is_pyodide_context():
+            return await self._response.text
+        
+        return self._response.text
+
+    async def blob(self):
+        if is_pyodide_context():
+            return await self._response.blob()
+        
+        return self._response.content
+
+    @staticmethod
+    async def get(*args, **kwargs):
+        _request = Request("GET", *args, **kwargs)
+        await _request.perform()
+        return _request
+
+
+    @staticmethod
+    async def post(*args, **kwargs):
+        _request = Request("POST", *args, **kwargs)
+        await _request.perform()
+
+        return _request
+
+    @staticmethod
+    async def put(*args, **kwargs):
+        _request = Request("PUT", *args, **kwargs)
+        await _request.perform()
+
+        return _request
+
+    @staticmethod
+    async def delete(*args, **kwargs):
+        _request = Request("DELETE", *args, **kwargs)
+        await _request.perform()
+
+        return _request
+
+    @staticmethod
+    async def patch(*args, **kwargs):
+        _request = Request("PATCH", *args, **kwargs)
+        await _request.perform()
+
+        return _request

--- a/src/viur_cli/scriptor/scriptor/progressbar.py
+++ b/src/viur_cli/scriptor/scriptor/progressbar.py
@@ -3,7 +3,7 @@ from .utils import is_pyodide_context
 if is_pyodide_context():
     from js import self as _self
 
-def start(total: int, step: int = -1, max_step=-1, txt = ''):
+def start(total: int, step: int = -1, max_step: int = -1, txt = ""):
     if is_pyodide_context():
         _self.postMessage(type="progressbar", total=total, step=step, max_step=max_step, txt=txt)
 

--- a/src/viur_cli/scriptor/scriptor/progressbar.py
+++ b/src/viur_cli/scriptor/scriptor/progressbar.py
@@ -1,0 +1,14 @@
+from .utils import is_pyodide_context
+
+if is_pyodide_context():
+    from js import self as _self
+
+def start(total: int, step: int = -1, max_step=-1, txt = ''):
+    if is_pyodide_context():
+        _self.postMessage(type="progressbar", total=total, step=step, max_step=max_step, txt=txt)
+
+def stop():
+    start(100)
+
+def update(*args, **kwargs):
+    start(*args, **kwargs)

--- a/src/viur_cli/scriptor/scriptor/readers.py
+++ b/src/viur_cli/scriptor/scriptor/readers.py
@@ -1,0 +1,38 @@
+from .utils import is_pyodide_context
+
+if 1:
+	from .writer import Picker
+	if is_pyodide_context():
+		from js import console
+
+	class FilePickerReader(Picker):
+		TYPE_NAME = "showOpenFilePicker"
+
+		async def on_startup(self):
+			if is_pyodide_context():
+				self._content = await (await self._file.getFile()).text()
+				console.log(f"content_type:{type(self._content)}")
+			else:
+				self._content = self._file.read()
+
+		def __init__(self, file_object: object) -> str:
+			super().__init__()
+			self._file = file_object[0]
+			self._content: str = ""
+
+		async def close(self):
+			await self._file.close()
+
+		@property
+		def content(self) -> str:
+			return self._content
+		
+		def readlines(self):
+			return self._content.splitlines()
+	
+		def read(self):
+			return self._content
+		
+		def __str__(self) -> str:
+			return self._content
+		

--- a/src/viur_cli/scriptor/scriptor/utils.py
+++ b/src/viur_cli/scriptor/scriptor/utils.py
@@ -1,0 +1,22 @@
+import sys
+import json
+
+def is_pyodide_context():
+	return sys.platform == 'emscripten' or "pyodide" in sys.modules
+
+def get_json_object(text: str):
+	try:
+		return json.loads(text)
+	except ValueError as e:
+		return False
+	return True
+
+async def sleep(ms: int):
+	if is_pyodide_context():
+		import manager
+		await manager.sleep(ms)
+	else:
+		import asyncio
+		if ms > 0 or ms < 0:
+			ms = float(ms)/1000.0
+		await asyncio.sleep(ms)

--- a/src/viur_cli/scriptor/scriptor/viur.py
+++ b/src/viur_cli/scriptor/scriptor/viur.py
@@ -1,0 +1,204 @@
+from .network import Request
+from .utils import is_pyodide_context
+from urllib.parse import urlencode as _urlencode
+
+if is_pyodide_context():
+    from js import console, fetch
+    from config import BASE_URL
+
+class viur:
+
+    class request(Request):
+        def __init__(self, method: str, url: str, params=None, renderer: str = None):
+
+            if not url.startswith("/"):
+                url = "/" + url
+
+            prefix = "/json"
+            if renderer:
+                prefix = "/" + renderer
+
+            url = self.build_url(prefix + url)
+
+            super().__init__(
+                method, 
+                url, 
+                credentials=True,
+                data=params, 
+                headers= {
+                    "Accept": "application/json, text/plain, */*",
+                }
+            )
+
+
+        @staticmethod
+        def build_url(url):
+            if url and not (url.startswith('http://') or url.startswith('https://') or url.startswith('//')):
+                url = BASE_URL + url
+
+            return url
+
+        @staticmethod
+        async def get(*args, **kwargs):
+            _request = viur.request("GET", *args, **kwargs)
+            await _request.perform()
+            return await _request.json()
+
+
+        @staticmethod
+        async def post(*args, **kwargs):
+            _request = viur.request("POST", *args, **kwargs)
+            await _request.perform()
+
+            return await _request.json()
+
+        @staticmethod
+        async def secure_post(url, params=None, renderer: str = None):
+            req = viur.request("GET", "/skey", renderer=renderer)
+            await req.perform()
+
+            skey = await req.json()
+            if not params:
+                params = {
+                    "skey": skey
+                }
+            else:
+                params.update({
+                    "skey": skey
+                })
+
+            return await viur.request.post(url, params, renderer)
+
+
+
+    @staticmethod
+    def build_url(action: str, url: str, module: str, group: str = "", key: str = ""):
+        _url = url
+        if not _url:
+            assert module, "You need to set an url or use the module parameter."
+            _url = f"{module}/{action}"
+            if group:
+                _url += f"/{group}"
+            if key:
+                _url += f"/{key}"
+        return _url
+
+
+    @staticmethod
+    async def view(*, url: str = "", module: str = "", key: str = "", params: dict = None, group: str = "", **kwargs):
+        _url = viur.build_url("view", url, module, group, key)
+
+        if not (ret := await viur.request.get(_url, params, **kwargs)):
+            return ret
+
+        return ret["values"]
+
+    @staticmethod
+    async def edit(*, url: str = "", module: str = "", key: str = "", params: dict = None, group: str = "", **kwargs):
+        url = viur.build_url("edit", url, module, group, key)
+
+        if not (ret := await viur.request.secure_post(url, params, **kwargs)):
+            return ret
+
+        return ret
+
+    @staticmethod
+    async def structure(*, url: str = "", module: str = "", group: str = "", **kwargs):
+        url = viur.build_url("structure", url, module, group)
+
+
+        if not (ret := await viur.request.get(url, **kwargs)):
+            return ret
+
+        return ret
+
+    @staticmethod
+    async def preview(*, url: str = "", module: str = "", group: str = "", params: dict = None, **kwargs):
+        url = viur.build_url("preview", url, module, group)
+
+
+        if not (ret := await viur.request.secure_post(url, params, **kwargs)):
+            return ret
+
+        return ret
+
+    @staticmethod
+    async def add(*, url: str = "", module: str = "", params: dict = None, group: str = "", **kwargs):
+        url = viur.build_url("add", url, module, group)
+
+        if not (ret := await viur.request.secure_post(url, params, **kwargs)):
+            return ret
+
+        return ret
+
+    @staticmethod
+    async def delete(*, url: str = "", module: str = "", key: str = "", params: dict = None, group: str = "", **kwargs):
+        url = viur.build_url("delete", url, module, group, key)
+
+        if not (ret := await viur.request.secure_post(url, params, **kwargs)):
+            return ret
+
+        return ret
+
+    @staticmethod
+    async def list_root_nodes(*, url: str = "", module: str = "", params: dict = None, group: str = "", **kwargs):
+        _url = viur.build_url("view", url, module, group)
+
+        if not (ret := await viur.request.get(_url, params, **kwargs)):
+            return ret
+
+        return ret["values"]
+
+    class list:
+        """
+        Fetches a list from a VIUR module
+        """
+
+        def __init__(self, *, url: str = "", module: str = "", params: dict = None, group: str = "",
+                     renderer: str = ""):
+            self._module = module
+            self._params = params or {}
+            if not url:
+                assert module, "You need to set an url or use the module parameter."
+                self._url = f"{module}/{self.__class__.__name__}"
+                if group:
+                    self._url += f"/{group}"
+            else:
+                self._url = url
+
+            self._renderer = renderer
+
+            self.batch = []
+            self.cursor = None
+            self.fetched = False
+
+        def __aiter__(self):
+            self.cursor = None
+            self.fetched = False
+            return self
+
+        async def __anext__(self):
+            if self.batch:
+                return self.batch.pop()
+
+            if self.fetched and not self.cursor:
+                raise StopAsyncIteration
+
+            if self.cursor:
+                self._params["cursor"] = self.cursor
+
+            ret = await viur.request.get(self._url, self._params, renderer=self._renderer)
+            self.fetched = True
+
+            if not ret:
+                raise StopAsyncIteration
+
+            self.batch = ret["skellist"]
+            self.cursor = ret["cursor"]
+
+            if not self.batch:
+                self.cursor = None
+
+            return await self.__anext__()
+
+

--- a/src/viur_cli/scriptor/scriptor/writer.py
+++ b/src/viur_cli/scriptor/scriptor/writer.py
@@ -1,0 +1,221 @@
+from io import StringIO
+from .utils import is_pyodide_context
+
+if is_pyodide_context():
+	from js import eval as js_eval, self as _self, Blob
+	from pyodide.ffi import to_js, create_once_callable
+	#import js_utils
+
+from .logger import Logging as logging
+
+class WriterBase:
+	LINE_TERMINATOR = '\n'
+
+	def __init__(self, line_terminator = LINE_TERMINATOR) -> None:
+		self._line_count = 0
+		self._offset = 0
+		self._line_terminator = line_terminator
+	
+	def increase_line_count(self):
+		self._line_count += 1
+	
+	@property
+	def line_terminator(self) -> str:
+		return self._line_terminator
+	
+	@line_terminator.setter
+	def line_terminator(self, value: str):
+		self._line_terminator = value
+	
+	@property
+	def line_count(self) -> int:
+		return self._line_count
+
+	@property
+	def offset(self):
+		return self._offset
+
+	def __len__(self) -> int:
+		return self._line_count
+
+	def write(self, content: str):
+		pass
+
+	def write_line(self, content: str):
+		pass
+
+	def write_lines(self, lines: list[str]):
+		for line in lines:
+			self.write_line(line)
+
+class MemoryWriter(WriterBase):
+	DEFAULT_FILE_NAME = "export.txt"
+
+	def __init__(self, content: str = "") -> None:
+		self._content = StringIO(content)
+		super().__init__()
+	
+	def write(self, content: str):
+		self._content.write(content)
+		self._line_count = self._content.getvalue().count(self._line_terminator)
+		self._offset = 0
+
+	def write_line(self, content: str):
+		self.increase_line_count()
+		_line = content + self._line_terminator
+		self._content.write(_line)
+		self._offset += len(_line)
+
+	def __str__(self) -> str:
+		return self._content.getvalue()
+
+	def clear(self):
+		self._content.truncate()
+
+	def download(self, name: str = ""):
+
+		if not name:
+			name = self.DEFAULT_FILE_NAME
+
+		if is_pyodide_context():
+			blob = Blob.new([str(self)], **{
+				"type": "application/csv;charset=utf-8;"
+			})
+
+			_self.postMessage(type="download", blob=blob, filename=name)
+		else:
+			with open(name, "w") as f:
+				f.write(str(self))
+
+if 1:
+	from .dialog import wait
+	if is_pyodide_context():
+		import manager
+	else:
+		import os
+		import click
+	
+	class Picker:
+		TYPE_NAME = ""
+
+		async def on_startup(self):
+			pass
+
+		@classmethod
+		async def open(cls):
+			#js_utils.registerEvent(cls.EVENT_NAME, create_once_callable(lambda handle, cb=callback: cls.on_handle_callback(handle, cb)))
+			if is_pyodide_context():
+				_self.postMessage(type=cls.TYPE_NAME)
+				await wait()
+
+				tmp = manager.copyResult()
+				manager.reset()
+				manager.resultValue = None
+
+				if tmp == -1 or not tmp:
+					return None
+
+				instance = cls(tmp)
+			else:
+				ret = click.prompt("Enter a path")
+
+				if cls.TYPE_NAME == "showOpenFilePicker":
+					instance = cls([open(ret, "r")])
+				else:
+					instance = cls(ret)
+
+			await instance.on_startup()
+			return instance
+
+
+	class FilePickerWriter(WriterBase, Picker):
+		TYPE_NAME = "showSaveFilePicker"
+
+		def __init__(self, file_object: object, line_terminator: str = WriterBase.LINE_TERMINATOR) -> str:
+			super().__init__(line_terminator)
+			self._file = file_object
+			self._file_stream = None
+
+		async def write(self, content: str):
+			if is_pyodide_context():
+				await self._file_stream.write(
+					type="write",
+					data=content 
+				)
+			else:
+				self._file_stream.seek(self._offset)
+				self._file_stream.write(content)
+
+			self._offset += len(content)
+			self.increase_line_count()
+
+		async def write_line(self, content: str):
+			content = content + self.line_terminator
+			# FIX WRITING!!
+
+			if is_pyodide_context():
+				encoder = js_eval("new TextEncoder()")
+				
+				await self._file_stream.write(
+					type="write",
+					data=encoder.encode(content)
+				)
+			else:
+				self._file_stream.seek(self._offset)
+				self._file_stream.write(content)
+
+			self._offset += len(content)
+			self.increase_line_count()
+
+		async def close(self):
+			if is_pyodide_context():
+				await self._file_stream.close()
+			else:
+				self._file_stream.close()
+
+		async def __aenter__(self):
+			if is_pyodide_context():
+				self._file_stream = await self._file.createWritable()
+			else:
+				self._file_stream = open(self._file, "a+")
+				self._file_stream.truncate()
+
+		async def __aexit__(self, *args):
+			await self.close()
+
+		def __len__(self):
+			return len(str(self._file))
+
+	class DirectoryPickerWriter(WriterBase, Picker):
+		TYPE_NAME = "showDirectoryPicker"
+
+		def __init__(self, directory_handle: object, line_terminator: str = WriterBase.LINE_TERMINATOR, parent_handle: object = None) -> str:
+			super().__init__(line_terminator)
+			self._directory_handle = directory_handle
+			if not is_pyodide_context():
+				if not os.path.exists(self._directory_handle):
+					os.makedirs(self._directory_handle)
+
+			self._parent_handle = parent_handle
+
+
+		async def file(self, path: str):
+			if self._directory_handle is None:
+				return None
+
+			if is_pyodide_context():
+				return FilePickerWriter(await self._directory_handle.getFileHandle(path, create=True), WriterBase.LINE_TERMINATOR)
+			
+			return FilePickerWriter(os.path.join(self._directory_handle, path), WriterBase.LINE_TERMINATOR)
+
+		async def directory(self, path: str):
+			if self._directory_handle is None:
+				return None
+
+			if is_pyodide_context():
+				return DirectoryPickerWriter(await self._directory_handle.getDirectoryHandle(path, create=True), WriterBase.LINE_TERMINATOR, self._directory_handle)
+
+			return DirectoryPickerWriter(os.path.join(self._directory_handle, path), WriterBase.LINE_TERMINATOR, self._directory_handle)
+		
+		def __len__(self):
+			return len(str(self._directory_handle))


### PR DESCRIPTION
This pull request replaces #30 as it is established on ab72af8d1693c2a9c54d49bcf42be447c938cbdb based on work by @ciansen (a lot of thanks to him!).

Adds the `viur script` command and sub-commands.
```
$ viur script
Usage: viur script [OPTIONS] COMMAND [ARGS]...

  Manage and run scriptor scripts locally on the console

Options:
  --help  Show this message and exit.

Commands:
  configure  Manage configuration settings
  pull       Pull contents from server to working_dir.
  push       Push contents of working_dir to server.
  run        Locally run a scriptor script located in the working_dir
  setup      Setup user session with a given username and password
```