### PR TITLE
fix: Don't assume "builds" in the default config

### DIFF
--- a/src/viur_cli/conf.py
+++ b/src/viur_cli/conf.py
@@ -291,7 +291,7 @@ def update_config(path=None):
 
     if projectConfig["default"]["format"] == "1.1.0":
         projectConfig["default"]["format"] = "1.1.1"
-        builds = projectConfig["default"]["builds"].copy()
+        builds = projectConfig["default"].get("builds", {}).copy()
         for k, v in builds.items():
             if builds[k]["kind"] == "script":
                 builds[k]["kind"] = "exec"


### PR DESCRIPTION
This PR fixes the case when running viur-cli==1.0.3 on a project.json that has been created with a version <1.0:
```
Traceback (most recent call last):
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/bin/viur", line 8, in <module>
    sys.exit(cli())
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/click/core.py", line 1654, in invoke
    super().invoke(ctx)
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/click/decorators.py", line 26, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/viur_cli/cli.py", line 15, in cli
    load_config()
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/viur_cli/conf.py", line 117, in load_config
    update_config(path)
  File "~/.local/share/virtualenvs/myproject-ecWVB2rO/lib/python3.10/site-packages/viur_cli/conf.py", line 294, in update_config
    builds = projectConfig["default"]["builds"].copy()
KeyError: 'builds'
```
