### PR TITLE
Support Python 3.11 as well

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ packages = find:
 python_requires = >=3.10
 install_requires =
     watchgod==0.7
-    python-minifier==2.5.0
+    python-minifier==2.9
     app_server==0.9.4
     click==8.1.3
     pipfile-requirements==0.3.0


### PR DESCRIPTION
This PR raises python-minifier to version 2.9, which does both support Python 3.10 and Python 3.11.
Otherwise, viur-cli cannot be installed in Python > 3.10.