### PR TITLE
feat: `viur build clean` command

### DIFF
--- a/src/viur_cli/build.py
+++ b/src/viur_cli/build.py
@@ -60,10 +60,46 @@ def _build(cfg, name, build_cfg, additional_args):
         case other:
             utils.echo_fatal(f"Unknown build kind {other!r}")
 
+def _clean(cfg, name, build_cfg):
+    """Internal function to perform steps required to clean a given configuration.
+
+    :param cfg: The project configuration (default, or project-specific)
+    :param name: Name of the app to clean.
+    :param build_cfg: The build-cfg for the specified app.
+    """
+    utils.echo_info(f"""- cleaning {build_cfg["kind"]} {name}""")
+
+    match build_cfg["kind"]:
+        # for flare and npm, drop the target folder and node_modules (npm)
+        case "flare" | "npm":
+            if target_dir := build_cfg.get("target"):
+                target_dir = os.path.join(cfg["distribution_folder"], target_dir)
+                utils.echo_info(f"  - dropping {target_dir}")
+                shutil.rmtree(target_dir)
+
+            if build_cfg["kind"] == "npm":
+                # todo: Later, call "npm run clean" or a similar command when it exists
+
+                node_modules = os.path.join(cfg["sources_folder"], build_cfg["source"], "node_modules")
+                utils.echo_info(f"  - dropping {node_modules}")
+                shutil.rmtree(os.path.join(node_modules))
+
+        case "exec":
+            pass
+
+        case other:
+            utils.echo_fatal(f"Unknown build kind {other!r}")
+
+    # Always execute explicit "clean" command if provided
+    if clean_cmd := build_cfg.get("clean"):
+        utils.echo_info(f"  - executing {clean_cmd=}")
+        utils.system(clean_cmd)
+
 
 @cli.group()
 def build():
     """Build VIUR project or specific apps."""
+
 
 @build.command(context_settings={"ignore_unknown_options": True})
 @click.argument("name", default='develop')
@@ -86,8 +122,9 @@ def release(name, additional_args):
 
     utils.echo_info("building finished!")
 
+
 @build.command(context_settings={"ignore_unknown_options": True})
-@click.argument("appname", default="")
+@click.argument("appname")
 @click.argument("additional_args", nargs=-1)
 def app(appname, additional_args):
     """Build specific app."""
@@ -102,3 +139,25 @@ def app(appname, additional_args):
     utils.echo_info("building started...")
     _build(cfg, appname, build_cfg, additional_args)
     utils.echo_info("building finished!")
+
+
+@build.command
+@click.argument("target", default="")
+def clean(target):
+    """Clean-up build artefacts."""
+    projectConfig = conf.get_config()
+    cfg = projectConfig["default"].copy()
+
+    builds = cfg.get("builds", {})
+    if target:
+        if not (build_cfg := builds.get(target)):
+            utils.echo_fatal(f"""{target=} must be one of these options: {", ".join(cfg["builds"].keys())}""")
+
+        builds = {target: build_cfg}
+
+    utils.echo_info("clean started...")
+
+    for build_name, build_cfg in builds.items():
+        _clean(cfg, build_name, build_cfg)
+
+    utils.echo_info("clean finished!")


### PR DESCRIPTION
This introduces a new command to clean-up apps.

- `viur build clean` cleans all builds of the project
- `viur build clean <app>` cleans the specified build config only

Features:

1. Introduces a "clean" command that can be provided by any build config
2. For "flare" and "npm", the target-folder is removed, if specified
3. For "npm", the "node_modules" folder in source is removed

---
Example configuration (tested!):
```json
"builds": {
    "app": {
        "command": "build",
        "kind": "npm",
        "source": "app",
        "target": "static/app"
    },
    "scriptor": {
        "command": "build",
        "kind": "npm",
        "source": "scriptor",
        "target": "scriptor"
    },
    "vi": {
        "clean": "rm -rf ./deploy/vi",
        "command": "flare -s sources/vi/vi -t deploy/vi",
        "kind": "exec"
    }
}
```
---
Example run
```
$ viur build clean
clean started...
- cleaning npm app
  - dropping ./deploy/static/app
  - dropping ./sources/app/node_modules
- cleaning npm scriptor
  - dropping ./deploy/scriptor
  - dropping ./sources/scriptor/node_modules
- cleaning exec vi
  - executing clean_cmd='rm -rf ./deploy/vi'
clean finished!
```