### PR TITLE
Improving vulnerability checks

### DIFF
--- a/src/viur_cli/local.py
+++ b/src/viur_cli/local.py
@@ -1,4 +1,4 @@
-import click, os, sys, shutil, subprocess
+import click, os, shutil, subprocess
 from . import cli, echo_error, get_config, utils
 from .install import vi as vi_install
 


### PR DESCRIPTION
This is a bugfix and refactoring of the audit check executed when `viur deploy app` is invoked.

It seems there is a problem with newer `npm` versions, which return an non-zero exitcode, resulting in this traceback in the current version 1.0.10 of viur-cli:
```
$ viur deploy app 
Traceback (most recent call last):
  File "~/.local/share/virtualenvs/project-0hzhGwnX/bin/viur", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "~/.local/share/virtualenvs/project-0hzhGwnX/lib/python3.11/site-packages/click/core.py", line 1130, in __call__
    return self.main(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.local/share/virtualenvs/project-0hzhGwnX/lib/python3.11/site-packages/click/core.py", line 1055, in main
    rv = self.invoke(ctx)
         ^^^^^^^^^^^^^^^^
  File "~/.local/share/virtualenvs/project-0hzhGwnX/lib/python3.11/site-packages/click/core.py", line 1657, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.local/share/virtualenvs/project-0hzhGwnX/lib/python3.11/site-packages/click/core.py", line 1404, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.local/share/virtualenvs/project-0hzhGwnX/lib/python3.11/site-packages/click/core.py", line 760, in invoke
    return __callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "~/.local/share/virtualenvs/project-0hzhGwnX/lib/python3.11/site-packages/viur_cli/deploy.py", line 22, in deploy
    if not do_checks(dev=False):
           ^^^^^^^^^^^^^^^^^^^^
  File "~/.local/share/virtualenvs/project-0hzhGwnX/lib/python3.11/site-packages/viur_cli/local.py", line 168, in do_checks
    result = subprocess.check_output(("npm", "audit", "--omit", "dev", "--prefix", path))
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 466, in check_output
    return run(*popenargs, stdout=PIPE, timeout=timeout, check=True,
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/subprocess.py", line 571, in run
    raise CalledProcessError(retcode, process.args,
subprocess.CalledProcessError: Command '('npm', 'audit', '--omit', 'dev', '--prefix', './sources/app')' returned non-zero exit status 1.
```

This pull request now fixes the code and refactors it, so that the pipenv check/npm audit run is only done once, and its output is reported in case it doesn't contain the desired output. 
