### PR TITLE
Feature/remove index yaml duplicates

### DIFF
--- a/src/viur_cli/deploy.py
+++ b/src/viur_cli/deploy.py
@@ -145,12 +145,8 @@ def check_index_duplicates(file_path):
             seen.add((kind, properties))
 
     if duplicates:
-        print("Duplicate(s) found in index.yaml ")
-
-        delete_input = input("Do you want to delete index.yaml duplicates? (Y/n)").lower().strip()
-
-        if delete_input == 'y' or delete_input == '':
-            remove_duplicates(file_path, duplicates)
+        echo_info("Duplicate(s) found in index.yaml and will be automatically deleted ")
+        remove_duplicates(file_path, duplicates)
 
 
 def remove_duplicates(file_path, duplicates):

--- a/src/viur_cli/deploy.py
+++ b/src/viur_cli/deploy.py
@@ -89,7 +89,6 @@ def deploy(action, name, additional_args):
         yaml_file = f'{conf["distribution_folder"]}/{action}.yaml'
 
         # Sort index.yaml by kind name, making it more clean to view.
-        # Sort index.yaml by kind name, making it more clean to view.
         if action == "index":
 
             check_index_duplicates(yaml_file)


### PR DESCRIPTION
Implemented a check, that deletes duplicate index.yaml entries if found. 
Connected to Issue #67 
The Prompt now occurs, when the User tries to deploy an index.yaml file with duplicates.