### PR TITLE
fix: Exit `check_req` if `core_requirements` is `None`

### DIFF
--- a/src/viur_cli/update.py
+++ b/src/viur_cli/update.py
@@ -105,6 +105,7 @@ def check_req(projects_requirements_path):
 
     if not core_requirements:
         echo_error("could now find core package, please update the core to validate the requirements.txt")
+        return
 
     core_requirements_obj = utils.requirements_to_dict(parse_requirements(core_requirements, session=PipSession()))
 


### PR DESCRIPTION
Otherwise the following statement crashes.

---

Steps to reproduce:
1. Install viur-core as editable
2. deploy app