### PR TITLE
fix: Remove typo 4

### DIFF
--- a/src/viur_cli/conf.py
+++ b/src/viur_cli/conf.py
@@ -122,7 +122,7 @@ class ProjectConfig(dict):
             self.find_key(self, target_key="version", target="default", keep=True)
             # Fail Safe
             if "version" in self:
-                del self["version"]  4
+                del self["version"]
         self.remove_key(self, target_key="core")
 
         if old_format := self["default"].get("format"):


### PR DESCRIPTION
No idea where this `4` belongs, but definitely not here. This leads to a `SyntaxError`.