### PR TITLE
feat: Implement variable substitution for `app.yaml`

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,12 @@ It contains the default viur project profile and it can be expanded with several
                 "kind": "npm",
                 "source": ""
             }
+            /* OPTIONAL arguments, can be put in default or in a specific profile */
+            "appyaml": "app_stub.yaml",  // Use an other name as "app.yaml"
+            "appyaml_substitition": true,  // Set to true to substitute only default variables in app.yaml
+            "appyaml_substitition": {  // Set to an object to substitute these additionally to default variables in app.yaml
+                "$REGION": "europe-west3"
+            }
         },
         "gcloud": {
             "functions": { //Declarations for a cloud function

--- a/README.md
+++ b/README.md
@@ -174,10 +174,10 @@ It contains the default viur project profile and it can be expanded with several
                 "kind": "npm",
                 "source": ""
             }
-            /* OPTIONAL arguments, can be put in default or in a specific profile */
-            "appyaml": "app_stub.yaml",  // Use an other name as "app.yaml"
-            "appyaml_substitition": true,  // Set to true to substitute only default variables in app.yaml
-            "appyaml_substitition": {  // Set to an object to substitute these additionally to default variables in app.yaml
+            /* OPTIONAL arguments, can be set in default or in a specific profile */
+            "appyaml": "app_stub.yaml",  // Use a name other than "app.yaml"
+            "appyaml_substitition": true,  // Set to true to replace only standard variables in app.yaml
+            "appyaml_substitition": {  // Set to an object to replace these in addition to the standard variables in app.yaml
                 "$REGION": "europe-west3"
             }
         },

--- a/src/viur_cli/cloud.py
+++ b/src/viur_cli/cloud.py
@@ -531,7 +531,7 @@ def deploy(action, profile, name, ext, yes, additional_args):
         # rebuild requirements.txt
         create_req(yes, profile, confirm_value=False)
 
-        app_yaml_tmp = None
+        app_yaml_tmp = app_yaml_hidden = None
         if appyaml_substitition := conf.get("appyaml_substitition"):
             app_yaml = Path(conf["distribution_folder"]) / conf.get("appyaml", "app.yaml")
             app_yaml_tmp = app_yaml.with_stem(f"app{time.time_ns()}.tmp")
@@ -551,9 +551,11 @@ def deploy(action, profile, name, ext, yes, additional_args):
             additional_args = [f"--appyaml={app_yaml_tmp.resolve()}", *additional_args]
 
             # Sadly the --appyaml does only work if the deploy dir does not contain an app.yaml,
-            # thefore we make it "hidden" for the gcloud CLI
-            app_yaml_hidden = app_yaml.with_stem(f".{app_yaml.stem}")
-            app_yaml.rename(app_yaml_hidden)
+            # thefore we make it "hidden" for the gcloud CLI if there is "app.yaml" is not
+            # named differently
+            if app_yaml.name == "app.yaml":
+                app_yaml_hidden = app_yaml.with_stem(f".{app_yaml.stem}")
+                app_yaml.rename(app_yaml_hidden)
 
         try:
             os.system(
@@ -563,6 +565,7 @@ def deploy(action, profile, name, ext, yes, additional_args):
         finally:
             if app_yaml_tmp is not None:
                 app_yaml_tmp.unlink()
+            if app_yaml_hidden is not None:
                 app_yaml_hidden.rename(app_yaml)
 
     elif action == "cloudfunction":

--- a/src/viur_cli/cloud.py
+++ b/src/viur_cli/cloud.py
@@ -531,9 +531,9 @@ def deploy(action, profile, name, ext, yes, additional_args):
         # rebuild requirements.txt
         create_req(yes, profile, confirm_value=False)
 
+        app_yaml = Path(conf["distribution_folder"]) / conf.get("appyaml", "app.yaml")
         app_yaml_tmp = app_yaml_hidden = None
         if appyaml_substitition := conf.get("appyaml_substitition"):
-            app_yaml = Path(conf["distribution_folder"]) / conf.get("appyaml", "app.yaml")
             app_yaml_tmp = app_yaml.with_stem(f"app{time.time_ns()}.tmp")
 
             susbtitutions = {
@@ -556,6 +556,10 @@ def deploy(action, profile, name, ext, yes, additional_args):
             if app_yaml.name == "app.yaml":
                 app_yaml_hidden = app_yaml.with_stem(f".{app_yaml.stem}")
                 app_yaml.rename(app_yaml_hidden)
+
+        elif app_yaml.name != "app.yaml":
+            # No substitution is used, but an different app.yaml name
+            additional_args = [f"--appyaml={app_yaml_tmp.resolve()}", *additional_args]
 
         try:
             os.system(

--- a/src/viur_cli/local.py
+++ b/src/viur_cli/local.py
@@ -46,6 +46,10 @@ def run(profile, additional_args):
                    f"Please install the 'gcloud' tool or Log in with an appropriate account.")
 
     conf = config.get_profile(profile)
+
+    if appyaml := conf.get("appyaml"):
+        additional_args = [f"--appyaml={appyaml}", *additional_args]
+
     utils.system(
         f'app_server -A={conf["application_name"]} {conf["distribution_folder"]} {" ".join(additional_args)}')
 


### PR DESCRIPTION
Unfortunately, Google is too lazy to implement variable substitution in `app.yaml`.

Therefore, we have to replace it ourselves before deploying.
To do this, we create a temporary copy of `app.yaml` where we replace variables from the default `app.yaml` that acts as a stub.
Then we use the `--appyaml` argument of `gcloud app deploy` to deploy with the temporary `app.yaml`.


---

This PRs belongs together with https://github.com/viur-framework/viur-app_server/pull/8