### PR TITLE
feat: Make `viur package install ...` more handy

### DIFF
--- a/src/viur_cli/package.py
+++ b/src/viur_cli/package.py
@@ -85,8 +85,8 @@ def get_version_info(software: str, version: str) -> tuple[str, str]:
 @cli.command()
 @click.argument('operation', type=click.Choice(['update', 'install']))
 @click.argument('component', type=click.Choice(['vi', 'admin', 'scriptor', 'all']))
-@click.argument('profile', default='default')
 @click.argument("version", default="latest")
+@click.argument('profile', default='default')
 def package(operation, component, profile, version):
     """
     Performs installements and updates of ViUR Ecosystem packages


### PR DESCRIPTION
Every ViUR project I know stores the packages in the default target. Therefore I suggest to change the argument order to make the command shorter because you can now omit the profile, but specify version.