### PR TITLE
fix: Re-Add `--appyaml` argument for app_server

### DIFF
--- a/src/viur_cli/local.py
+++ b/src/viur_cli/local.py
@@ -48,11 +48,13 @@ def run(profile, additional_args):
     conf = config.get_profile(profile)
     additional_args = list(additional_args)
 
+    if appyaml := conf.get("appyaml"):
+        additional_args.append(f"--appyaml={appyaml}")
     if conf.get("port"):
         additional_args.append(f"--port={conf['port']}")
     if conf.get("gunicorn_port"):
         additional_args.append(f"--gunicorn_port={conf['gunicorn_port']}")
-        
+
     utils.system(
         f'app_server -A={conf["application_name"]} {conf["distribution_folder"]} {" ".join(additional_args)}')
 


### PR DESCRIPTION
Introduced in https://github.com/viur-framework/viur-cli/pull/187/files#diff-b9d754dcb486774363b646fd5dedb62476a91bb7f97f287dbd409a6f3613dc76R49-R52 
and get lost anywhere (probably during wrong merge) in https://github.com/viur-framework/viur-cli/pull/178/files

This makes the current viur-cli not working for me, since I cannot start the dev server. So I still need to stuck on 781d8bb445088ca6d403a3f5feaf05d0d3fd3f25 ...