### PR TITLE
fix: Configurable target path for package install/update

### DIFF
--- a/src/viur_cli/package.py
+++ b/src/viur_cli/package.py
@@ -110,10 +110,12 @@ def package(operation, component, profile, version):
     }
 
     def perform_operation(component, version):
+        # Use target from builds config if available, otherwise fall back to component name
+        target = conf.get("builds", {}).get(component, {}).get("target", component)
         if operation == 'install':
-            operations_links[component](version, target=component, profile=profile)
+            operations_links[component](version, target=target, profile=profile)
         else:
-            operations_links[component](version="latest", target=component, profile=profile)
+            operations_links[component](version="latest", target=target, profile=profile)
 
     match component:
         case 'vi':
@@ -251,7 +253,7 @@ def vi(version, target, profile):
             elif element == 3:
                 with zipfile.ZipFile(tmp_zip_file) as zip_f:
                     zip_f.extractall(vi_path)
-            elif element == 5:
+            elif element == 4:
                 tmp_zip_file.unlink()
                 bar.label = "updated successful"
 


### PR DESCRIPTION
## Summary

- **Configurable target path:** `perform_operation()` now reads an optional `"target"` field from the builds config in `project.json`, falling back to the component name. This allows projects to control where packages are installed (e.g. installing `vi` into `deploy/admin/` instead of `deploy/vi/`).
- **Fix temp file cleanup in `vi()`:** `element == 5` was a typo — should be `element == 4`. The temp zip file `vi.zip` was never deleted after installation.

## Problem

When running `viur package update vi`, the target directory was hardcoded to the component name:

```python
operations_links[component](version, target=component, ...)
#                                    target="vi" → deploy/vi/
```

Projects that expect the admin UI at `deploy/admin/` had no way to override this.

## Solution

```python
target = conf.get("builds", {}).get(component, {}).get("target", component)
```

Projects can now optionally set a `"target"` field in their builds config:

```json
{
    "builds": {
        "vi": {
            "command": "viur package install vi",
            "kind": "exec",
            "version": "3.0.37",
            "target": "admin"
        }
    }
}
```

Without `"target"`, behavior is unchanged (falls back to component name).

## Test plan

- [x] `viur package update admin` installs to `deploy/admin/` (unchanged)
- [x] `viur package install admin` installs to `deploy/admin/` (unchanged)
- [ ] `viur package update vi` with `"target": "admin"` in config installs to `deploy/admin/`
- [ ] Without `"target"` field: behavior unchanged (backward compatible)