### PR TITLE
feat: Use get_cookie_for_app to login

### DIFF
--- a/src/viur_cli/scriptor/cli.py
+++ b/src/viur_cli/scriptor/cli.py
@@ -12,6 +12,7 @@ from weakref import proxy
 from viur.scriptor import Modules
 from ..cli import cli
 from ..cli import scriptor_config
+from .login import ensure_login
 
 # Global modules instance that will be initialized when needed
 _modules = None
@@ -43,7 +44,6 @@ def configure(url: str, username: str, working_dir: str):
     Manage configuration settings.
     """
 
-
     if url:
         scriptor_config["base_url"] = url
 
@@ -61,6 +61,14 @@ def setup():
     """
 
     base_url = scriptor_config.get("base_url")
+
+    try:
+        click.echo("This Feature is only avalible on viur-core 3.8.19 or higher.")
+        res = ensure_login("", host=base_url)
+        if res:
+            return
+    except KeyboardInterrupt:
+        pass
     try:
         session = requests.session()
         skey = session.get(base_url + "/json/skey")
@@ -96,13 +104,11 @@ def check_session(ctx: click.Context):
 
     response = s.get(base_url + "/vi/user/view/self", cookies=scriptor_config.get("cookies", {}))
     if not response.ok:
-        click.echo("Invalid session, please run `viur script setup` again.")
+        click.echo("Invalid session, please run `viur script setup` again. okay ?")
         ctx.invoke(setup)
         ctx.close()
-    #FIXME We need this ?
-    # Update modules with cookies
-    modules = get_modules()
-    # modules.request.cookies = cookiejar_from_dict(scriptor_config.get("cookies", {}))
+    # init modules
+    get_modules()
 
 
 @script.command()
@@ -113,7 +119,6 @@ def pull(ctx: click.Context, force: bool):
     Pull contents from server to working_dir.
     """
     check_session(ctx)
-
 
     async def main():
         # In the new API, we don't need to call structure

--- a/src/viur_cli/scriptor/login.py
+++ b/src/viur_cli/scriptor/login.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+import contextvars
+import json
+import urllib.parse
+import webbrowser
+from pathlib import Path
+from wsgiref.simple_server import  make_server
+from ..cli import scriptor_config
+import requests
+
+PORT = 60_000
+
+
+
+def callback_app(environ: dict, start_response):
+    qs = urllib.parse.parse_qs(environ["QUERY_STRING"])
+    callback_app.cookie.set(qs["cookie"][0])
+    callback_app.app.set(qs["app"][0])
+    start_response("200 OK", [('Content-Type', 'text/plain; charset=utf-8')])
+    return [b"This was successful. You can now close this site."]
+
+
+callback_app.cookie = contextvars.ContextVar("Cookie")
+callback_app.app = contextvars.ContextVar("App")
+
+
+def ensure_login(
+    app: str,
+    *,
+    open_browser: bool = True,
+    host: str = None,
+) -> bool:
+
+
+    with make_server('', PORT, callback_app) as httpd:
+        sa = httpd.socket.getsockname()
+        print("Serving HTTP on", sa[0], "port", sa[1], "...")
+
+        if host is None:
+            host = f"https://{app}.appspot.com"
+        url = f'{host}/vi/user/get_cookie_for_app?redirect_to=http://localhost:{PORT}'
+        if open_browser:
+            webbrowser.open(url)
+        else:
+            print("Open this URL in your browser:")
+            print(url)
+
+        httpd.handle_request()  # serve one request, then exit
+
+        cookie_str: str = callback_app.cookie.get()
+        key, value = cookie_str.split(";", 1)[0].split("=")
+        scriptor_config.get("cookies",{})[key] = value
+        scriptor_config.save()
+
+        return True
+
+
+
+


### PR DESCRIPTION
With this PR the cli uses `get_cookie_for_app` endpoint with a local callback server to  authenticate the user via browser instead of `username/password`.
As a fallback username/password works too.
