### PR TITLE
fix: Add get_modules in check_session

### DIFF
--- a/src/viur_cli/scriptor/cli.py
+++ b/src/viur_cli/scriptor/cli.py
@@ -107,8 +107,9 @@ def check_session(ctx: click.Context):
         click.echo("Invalid session, please run `viur script setup` again. okay ?")
         ctx.invoke(setup)
         ctx.close()
+    # init modules
+    get_modules()
 
-        
 @script.command()
 @click.option('--force', default=False, help='Force replace files from server in local working directory')
 @click.pass_context


### PR DESCRIPTION
Fixes
```
Traceback (most recent call last):
  File "/.local/share/virtualenvs/ag-dev-lcuCThDg/bin/viur", line 7, in <module>
    sys.exit(cli())
             ~~~^^
  File "/.local/share/virtualenvs/ag-dev-lcuCThDg/lib/python3.13/site-packages/click/core.py", line 1161, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/.local/share/virtualenvs/ag-dev-lcuCThDg/lib/python3.13/site-packages/click/core.py", line 1082, in main
    rv = self.invoke(ctx)
  File "/.local/share/virtualenvs/ag-dev-lcuCThDg/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/.local/share/virtualenvs/ag-dev-lcuCThDg/lib/python3.13/site-packages/click/core.py", line 1697, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/.local/share/virtualenvs/ag-dev-lcuCThDg/lib/python3.13/site-packages/click/core.py", line 1443, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/.local/share/virtualenvs/ag-dev-lcuCThDg/lib/python3.13/site-packages/click/core.py", line 788, in invoke
    return __callback(*args, **kwargs)
  File "/.local/share/virtualenvs/ag-dev-lcuCThDg/lib/python3.13/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Schreibtisch/work/ag-dev/viur-cli/src/viur_cli/scriptor/cli.py", line 163, in pull
    asyncio.new_event_loop().run_until_complete(main())
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/.pyenv/versions/3.13.11/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Schreibtisch/work/ag-dev/viur-cli/src/viur_cli/scriptor/cli.py", line 123, in main
    modules = get_modules()
  File "/Schreibtisch/work/ag-dev/viur-cli/src/viur_cli/scriptor/cli.py", line 26, in get_modules
    asyncio.new_event_loop().run_until_complete(_modules.init())
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/.pyenv/versions/3.13.11/lib/python3.13/asyncio/base_events.py", line 701, in run_until_complete
    self._check_running()
    ~~~~~~~~~~~~~~~~~~~^^
  File "/.pyenv/versions/3.13.11/lib/python3.13/asyncio/base_events.py", line 639, in _check_running
    raise RuntimeError(
        'Cannot run the event loop while another loop is running')
RuntimeError: Cannot run the event loop while another loop is running
```
Caused by https://github.com/viur-framework/viur-cli/pull/200/changes#diff-10f6200b0038a1bfb0d3a2d2940bd7d827f4ec3decbbee4b9f5702eb92e536d2L110-L111