### PR TITLE
fix: Strip leading `/` from server path in `script pull`

### DIFF
--- a/src/viur_cli/scriptor/cli.py
+++ b/src/viur_cli/scriptor/cli.py
@@ -126,7 +126,7 @@ def pull(ctx: click.Context, force: bool):
         working_dir = scriptor_config.get("working_dir")
 
         async def process_entry(entry: dict, is_node: bool):
-            _path = os.path.join(working_dir, entry["path"])
+            _path = os.path.join(working_dir, entry["path"].lstrip("/"))
 
             if is_node:
                 if not os.path.exists(_path):


### PR DESCRIPTION
`os.path.join` ignores the working directory when the second argument is an absolute path. Server-side `path` values start with `/`, causing files to be written to the filesystem root instead of `working_dir`.