### PR TITLE
fix: Mark `scriptor pull`'s `--force` as flag

### DIFF
--- a/src/viur_cli/scriptor/cli.py
+++ b/src/viur_cli/scriptor/cli.py
@@ -111,7 +111,8 @@ def check_session(ctx: click.Context):
     get_modules()
 
 @script.command()
-@click.option('--force', default=False, help='Force replace files from server in local working directory')
+@click.option('--force', default=False, is_flag=True,
+              help='Overwrite local files without asking for confirmation')
 @click.pass_context
 def pull(ctx: click.Context, force: bool):
     """


### PR DESCRIPTION
No longer needed to write `--force True` -- just `--force`

... and improve help text.