### PR TITLE
fix(scriptor): persist cookie on login by using setdefault instead of…

### DIFF
--- a/src/viur_cli/scriptor/login.py
+++ b/src/viur_cli/scriptor/login.py
@@ -49,7 +49,7 @@ def ensure_login(
 
         cookie_str: str = callback_app.cookie.get()
         key, value = cookie_str.split(";", 1)[0].split("=")
-        scriptor_config.get("cookies",{})[key] = value
+        scriptor_config.setdefault("cookies", {})[key] = value
         scriptor_config.save()
 
         return True

--- a/src/viur_cli/version.py
+++ b/src/viur_cli/version.py
@@ -1,2 +1,2 @@
-__version__ = "2.3.6"
+__version__ = "2.3.9"
 MINIMAL_PIPENV = "2023.11.15"


### PR DESCRIPTION
The dictionary in the credential-file was missing the key "cookie" on initial `viur script setup`. 
Use `.setdefault` instead `.get` to make sure that key "cookie" will be created if it doesn't exist.